### PR TITLE
Add support for \z in regexps

### DIFF
--- a/lib/arel_extensions/comparators.rb
+++ b/lib/arel_extensions/comparators.rb
@@ -37,13 +37,14 @@ module ArelExtensions
     end
 
     private
-    #Function use for not_regexp
+    # Function used for not_regexp.
     def convert_regexp(other)
       case other
       when String
-        #Do nothing
+        # Do nothing.
       when Regexp
         other = other.source.gsub('\A','^')
+        other.gsub!('\z','$')
         other.gsub!('\Z','$')
         other.gsub!('\d','[0-9]')
         other.gsub!('\D','[^0-9]')

--- a/test/visitors/test_oracle.rb
+++ b/test/visitors/test_oracle.rb
@@ -50,6 +50,7 @@ module ArelExtensions
         compile((c >= 'test').as('new_name')).must_be_like %{("users"."name" >= 'test') AS new_name}
         compile(c <= @table[:comments]).must_be_like %{"users"."name" <= "users"."comments"}
         compile(c =~ /\Atest\Z/).must_be_like %{REGEXP_LIKE("users"."name", '^test$')}
+        compile(c =~ /\Atest\z/).must_be_like %{REGEXP_LIKE("users"."name", '^test$')}
         compile(c =~ '^test$').must_be_like %{REGEXP_LIKE("users"."name", '^test$')}
         compile(c !~ /\Ate\Dst\Z/).must_be_like %{NOT REGEXP_LIKE("users"."name", '^te[^0-9]st$')}
         compile(c.imatches('%test%')).must_be_like %{LOWER("users"."name") LIKE LOWER('%test%')}

--- a/test/visitors/test_to_sql.rb
+++ b/test/visitors/test_to_sql.rb
@@ -88,6 +88,7 @@ module ArelExtensions
         compile((c >= 'test').as('new_name')).must_be_like %{("users"."name" >= 'test') AS new_name}
         compile(c <= @table[:comments]).must_be_like %{"users"."name" <= "users"."comments"}
         compile(c =~ /\Atest\Z/).must_be_like %{"users"."name" REGEXP '^test$'}
+        compile(c =~ /\Atest\z/).must_be_like %{"users"."name" REGEXP '^test$'}
         compile(c !~ /\Ate\Dst\Z/).must_be_like %{"users"."name" NOT REGEXP '^te[^0-9]st$'}
         compile(c.imatches('%test%')).must_be_like %{"users"."name" ILIKE '%test%'}
         compile(c.imatches_any(['%test%', 't2'])).must_be_like %{(("users"."name" ILIKE '%test%') OR ("users"."name" ILIKE 't2'))}


### PR DESCRIPTION
It appears that there is quite some redundancy in the tests inside test_to_sql.rb.