### PR TITLE
Fix .floor calculations for SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ User.connection.execute(insert_manager.to_sql)
     <td class="tg-yw4l">CEIL<br>column.ceil</td>
     <td class="ok">✔</td>
     <td class="ok">✔</td>
-    <td class="tg-j6lv">CASE + ROUND</td>
+    <td class="tg-j6lv">CASE + CAST</td>
     <td class="ok">✔</td>
     <td class="tg-j6lv">CEILING()</td>
     <td class="tg-j6lv">CEILING()</td>
@@ -218,7 +218,7 @@ User.connection.execute(insert_manager.to_sql)
     <td class="tg-yw4l">FLOOR<br>column.floor</td>
     <td class="ok">✔</td>
     <td class="ok">✔</td>
-    <td class="tg-j6lv">CASE + ROUND</td>
+    <td class="tg-j6lv">CASE + CAST</td>
     <td class="ok">✔</td>
     <td class="ok">✔</td>
     <td class="ok">✔</td>

--- a/functions.html
+++ b/functions.html
@@ -55,7 +55,7 @@
     <td class="tg-yw4l">CEIL<br>column.ceil</td>
     <td class="ok">✔</td>
     <td class="ok">✔</td>
-    <td class="tg-j6lv">CASE + ROUND</td>
+    <td class="tg-j6lv">CASE + CAST</td>
     <td class="ok">✔</td>
     <td class="tg-j6lv">CEILING()</td>
     <td class="tg-j6lv">CEILING()</td>
@@ -64,7 +64,7 @@
     <td class="tg-yw4l">FLOOR<br>column.floor</td>
     <td class="ok">✔</td>
     <td class="ok">✔</td>
-    <td class="tg-j6lv">CASE + ROUND</td>
+    <td class="tg-j6lv">CASE + CAST</td>
     <td class="ok">✔</td>
     <td class="ok">✔</td>
     <td class="ok">✔</td>

--- a/lib/arel_extensions/visitors/sqlite.rb
+++ b/lib/arel_extensions/visitors/sqlite.rb
@@ -193,13 +193,16 @@ module ArelExtensions
         collector
       end
 
-      # CASE
-      #   WHEN 3.42 >= 0 THEN CAST(3.42 AS INT)
-      #   WHEN CAST(3.42 AS INT) = 3.42 THEN CAST(3.42 AS INT)
-      #   ELSE CAST((3.42 - 1.0) AS INT)
-      # END
+      # CAST(
+      #   CASE
+      #     WHEN 3.42 >= 0 THEN CAST(3.42 AS INT)
+      #     WHEN CAST(3.42 AS INT) = 3.42 THEN CAST(3.42 AS INT)
+      #     ELSE CAST((3.42 - 1.0) AS INT)
+      #   END
+      #   AS FLOAT
+      # )
       def visit_ArelExtensions_Nodes_Floor o, collector
-        collector << "CASE WHEN "
+        collector << "CAST(CASE WHEN "
         collector = visit o.left, collector
         collector << " >= 0 THEN CAST("
         collector = visit o.left, collector
@@ -211,7 +214,7 @@ module ArelExtensions
         collector = visit o.left, collector
         collector << " AS INT) ELSE CAST(("
         collector = visit o.left, collector
-        collector << " - 1.0) AS INT) END"
+        collector << " - 1.0) AS INT) END AS FLOAT)"
         collector
       end
 

--- a/lib/arel_extensions/visitors/sqlite.rb
+++ b/lib/arel_extensions/visitors/sqlite.rb
@@ -193,18 +193,25 @@ module ArelExtensions
         collector
       end
 
-      # CASE WHEN ROUND(3.42,1) > round(3.42) THEN round(3.42) ELSE round(3.42)-1 END
-      # OR CAST(3.14 AS INTEGER)
+      # CASE
+      #   WHEN 3.42 >= 0 THEN CAST(3.42 AS INT)
+      #   WHEN CAST(3.42 AS INT) = 3.42 THEN CAST(3.42 AS INT)
+      #   ELSE CAST((3.42 - 1.0) AS INT)
+      # END
       def visit_ArelExtensions_Nodes_Floor o, collector
-        collector << "CASE WHEN ROUND("
+        collector << "CASE WHEN "
         collector = visit o.left, collector
-        collector << ", 1) > ROUND("
+        collector << " >= 0 THEN CAST("
         collector = visit o.left, collector
-        collector << ") THEN ROUND("
+        collector << " AS INT) WHEN CAST("
         collector = visit o.left, collector
-        collector << ") ELSE ROUND("
+        collector << " AS INT) = "
         collector = visit o.left, collector
-        collector << ") - 1 END"
+        collector << " THEN CAST("
+        collector = visit o.left, collector
+        collector << " AS INT) ELSE CAST(("
+        collector = visit o.left, collector
+        collector << " - 1.0) AS INT) END"
         collector
       end
 


### PR DESCRIPTION
The SQLite visitor is bugged under the following conditions:

1. when x = 10, x.floor is expected to be 10 but is 9
2. when x = 10.01, x.floor is expected to be 10 but is 9
3. when x = 0, x.floor is expected to be 0 but is -1
4. when x = -10.99, x.floor is expected to be -11 but is -12

Reimplementing the visitor to use CASE + CAST satisfies these conditions and fixes the floor implementation.
