### PR TITLE
in: accept arrays that contain ranges

### DIFF
--- a/test/visitors/test_to_sql.rb
+++ b/test/visitors/test_to_sql.rb
@@ -345,6 +345,13 @@ module ArelExtensions
           .must_be_like %{"users"."created_at" BETWEEN ('2016-03-31') AND ('2017-03-31')}
       end
 
+      it "should be possible to use a list of values and ranges on an IN" do
+        compile(@table[:id].in [1..10, 20, 30, 40..50))
+          .must_be_like %{(("users"."id" IN (20, 30)) OR ("users"."id" BETWEEN (1) AND (10))) OR ("users"."id" BETWEEN (40) AND (50))}
+#        compile(@table[:created_at].in(@date .. Date.new(2017, 3, 31))) # @date = Date.new(2016, 3, 31)
+#          .must_be_like %{"users"."created_at" BETWEEN ('2016-03-31') AND ('2017-03-31')}
+      end
+
       it "should be possible to add and substract as much as we want" do
         c = @table[:name]
         compile(c.locate('test')+1)


### PR DESCRIPTION
One would like to be able to run queries such as
```
User.where(User[:id].in [1..10, 20, 30..40, 50, nil])
```
and leave the desugaring to ArelX.

I'm sorry, this is only a draft: it is quite a task to be able to run purely syntactic tests of ArelX: I don't plan to install dbms, I just want to run the dummy tests such as test/visitors/test_to_sql.rb, but I saw no easy means to do it.  In fact I can't even run the code, there might be stupid syntactic errors. sorry about that.

This feature (on dates) would have been valuable in the project I work on.  I was lucky enough that ActiveRecord does support it.