### PR TITLE
tests: comply with recent versions of minitest

### DIFF
--- a/lib/arel_extensions/visitors/mysql.rb
+++ b/lib/arel_extensions/visitors/mysql.rb
@@ -101,11 +101,11 @@ module ArelExtensions
           case o.expressions.first
           when Arel::Attributes::Attribute
             case o.option
-              when 'latin1','utf8'
-                o.option
-              else
-                Arel::Table.engine.connection.charset || 'utf8'
-              end
+            when 'latin1','utf8'
+              o.option
+            else
+              Arel::Table.engine.connection.charset || 'utf8'
+            end
           else
             (o.option == 'latin1') ? 'latin1' : 'utf8'
           end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -9,10 +9,20 @@ require 'arel_extensions'
 require 'support/fake_record'
 Arel::Table.engine = FakeRecord::Base.new
 
-$arel_silence_type_casting_deprecation = true
+#$arel_silence_type_casting_deprecation = true
 
-class Object
-  def must_be_like other
-    gsub(/\s+/, ' ').strip.must_equal other.gsub(/\s+/, ' ').strip
+module Minitest::Assertions
+  #
+  #  Fails unless +expected and +actual are the same string, modulo extraneous spaces.
+  #
+  def assert_like(expected, actual, msg = nil)
+    msg ||= "Expected #{expected.inspect} and #{actual.inspect} to be alike"
+    assert_equal expected.gsub(/\s+/, ' ').strip, actual.gsub(/\s+/, ' ').strip
   end
+end
+
+module Minitest::Expectations
+
+  infect_an_assertion :assert_like, :must_be_like 
+
 end

--- a/test/test_comparators.rb
+++ b/test/test_comparators.rb
@@ -20,23 +20,24 @@ module ArelExtensions
       end
 
       it "< is equal lt" do
-        compile(@table[:id] < 10).must_be_like('"users"."id" < 10')
+        _(compile(@table[:id] < 10)).must_be_like('"users"."id" < 10')
       end
 
       it "<= is equal lteq" do
-        compile(@table[:id] <= 10).must_be_like('"users"."id" <= 10')
+        _(compile(@table[:id] <= 10)).must_be_like('"users"."id" <= 10')
       end
 
       it "> is equal gt" do
-        compile(@table[:id] > 10).must_be_like('"users"."id" > 10')
+        _(compile(@table[:id] > 10)).must_be_like('"users"."id" > 10')
       end
 
       it "< is equal gteq" do
-        compile(@table[:id] >= 10).must_be_like('"users"."id" >= 10')
+        _(compile(@table[:id] >= 10)).must_be_like('"users"."id" >= 10')
       end
 
       it "should compare with dates" do
-        compile(@table[:created_at] >= Date.new(2016, 3, 31)).must_be_like %{"users"."created_at" >= '2016-03-31'}
+        _(compile(@table[:created_at] >= Date.new(2016, 3, 31)))
+          .must_be_like %{"users"."created_at" >= '2016-03-31'}
       end
 
     end

--- a/test/visitors/test_bulk_insert_oracle.rb
+++ b/test/visitors/test_bulk_insert_oracle.rb
@@ -25,8 +25,9 @@ module ArelExtensions
       it "should import large set of data in Oracle" do
         insert_manager = Arel::VERSION.to_i > 6 ? Arel::InsertManager.new().into(@table) : Arel::InsertManager.new(@conn).into(@table)
         insert_manager.bulk_insert(@cols, @data)
-        sql = compile(insert_manager.ast)
-        sql.must_be_like %Q[INSERT INTO "users" ("name", "comments", "created_at") ((SELECT 'nom1', 'sdfdsfdsfsdf', '2016-01-01' FROM DUAL) UNION ALL (SELECT 'nom2', 'sdfdsfdsfsdf', '2016-01-01' FROM DUAL))]
+        _(compile(insert_manager.ast))
+          .must_be_like %Q[INSERT INTO "users" ("name", "comments", "created_at") 
+                        ((SELECT 'nom1', 'sdfdsfdsfsdf', '2016-01-01' FROM DUAL) UNION ALL (SELECT 'nom2', 'sdfdsfdsfsdf', '2016-01-01' FROM DUAL))]
       end
 
     end

--- a/test/visitors/test_bulk_insert_sqlite.rb
+++ b/test/visitors/test_bulk_insert_sqlite.rb
@@ -27,8 +27,9 @@ module ArelExtensions
       it "should import large set of data" do
         insert_manager = Arel::VERSION.to_i > 6 ? Arel::InsertManager.new().into(@table) : Arel::InsertManager.new(@conn).into(@table)
         insert_manager.bulk_insert(@cols, @data)
-        sql = compile(insert_manager.ast)
-        sql.must_be_like %Q[INSERT INTO "users" ("id", "name", "comments", "created_at") SELECT 23 AS 'id', 'nom1' AS 'name', 'sdfdsfdsfsdf' AS 'comments', '2016-01-01' AS 'created_at' UNION ALL SELECT 25, 'nom2', 'sdfdsfdsfsdf', '2016-01-01']
+        _(compile(insert_manager.ast))
+          .must_be_like %Q[INSERT INTO "users" ("id", "name", "comments", "created_at")
+                         SELECT 23 AS 'id', 'nom1' AS 'name', 'sdfdsfdsfsdf' AS 'comments', '2016-01-01' AS 'created_at' UNION ALL SELECT 25, 'nom2', 'sdfdsfdsfsdf', '2016-01-01']
       end
 
     end

--- a/test/visitors/test_bulk_insert_to_sql.rb
+++ b/test/visitors/test_bulk_insert_to_sql.rb
@@ -27,8 +27,8 @@ module ArelExtensions
       it "should import large set of data using ToSql" do
         insert_manager = Arel::VERSION.to_i > 6 ? Arel::InsertManager.new().into(@table) : Arel::InsertManager.new(@conn).into(@table)
         insert_manager.bulk_insert(@cols, @data)
-        sql = compile(insert_manager.ast)
-        sql.must_be_like %Q[INSERT INTO "users" ("id", "name", "comments", "created_at") VALUES (23, 'nom1', 'sdfdsfdsfsdf', '2016-01-01'), (25, 'nom2', 'sdfdsfdsfsdf', '2016-01-01')]
+        _(compile(insert_manager.ast))
+          .must_be_like %Q[INSERT INTO "users" ("id", "name", "comments", "created_at") VALUES (23, 'nom1', 'sdfdsfdsfsdf', '2016-01-01'), (25, 'nom2', 'sdfdsfdsfsdf', '2016-01-01')]
       end
     end
   end

--- a/test/visitors/test_oracle.rb
+++ b/test/visitors/test_oracle.rb
@@ -23,86 +23,86 @@ module ArelExtensions
       # Comparators
 
       it "should accept comparators on integers" do
-        compile(@table[:id] == 42).must_match %{"users"."id" = 42}
-        compile(@table[:id] == @table[:id]).must_be_like %{"users"."id" = "users"."id"}
-        compile(@table[:id] != 42).must_match %{"users"."id" != 42}
-        compile(@table[:id] > 42).must_match %{"users"."id" > 42}
-        compile(@table[:id] >= 42).must_match %{"users"."id" >= 42}
-        compile(@table[:id] >= @table[:id]).must_be_like %{"users"."id" >= "users"."id"}
-        compile(@table[:id] < 42).must_match %{"users"."id" < 42}
-        compile(@table[:id] <= 42).must_match %{"users"."id" <= 42}
-        compile((@table[:id] <= 42).as('new_name')).must_match %{("users"."id" <= 42) AS new_name}
+        _(compile(@table[:id] == 42)).must_match %{"users"."id" = 42}
+        _(compile(@table[:id] == @table[:id])).must_be_like %{"users"."id" = "users"."id"}
+        _(compile(@table[:id] != 42)).must_match %{"users"."id" != 42}
+        _(compile(@table[:id] > 42)).must_match %{"users"."id" > 42}
+        _(compile(@table[:id] >= 42)).must_match %{"users"."id" >= 42}
+        _(compile(@table[:id] >= @table[:id])).must_be_like %{"users"."id" >= "users"."id"}
+        _(compile(@table[:id] < 42)).must_match %{"users"."id" < 42}
+        _(compile(@table[:id] <= 42)).must_match %{"users"."id" <= 42}
+        _(compile((@table[:id] <= 42).as('new_name'))).must_match %{("users"."id" <= 42) AS new_name}
       end
 
       it "should accept comparators on dates" do
         c = @table[:created_at]
         u = @table[:updated_at]
-        compile(c > @date).must_be_like %{"users"."created_at" > '2016-03-31'}
-        compile(u >= @date).must_be_like %{"users"."updated_at" >= '2016-03-31'}
-        compile(c < u).must_be_like %{"users"."created_at" < "users"."updated_at"}
+        _(compile(c > @date)).must_be_like %{"users"."created_at" > '2016-03-31'}
+        _(compile(u >= @date)).must_be_like %{"users"."updated_at" >= '2016-03-31'}
+        _(compile(c < u)).must_be_like %{"users"."created_at" < "users"."updated_at"}
       end
 
       it "should accept comparators on strings" do
         c = @table[:name]
-        compile(c == 'test').must_be_like %{"users"."name" = 'test'}
-        compile(c != 'test').must_be_like %{"users"."name" != 'test'}
-        compile(c > 'test').must_be_like %{"users"."name" > 'test'}
-        compile((c >= 'test').as('new_name')).must_be_like %{("users"."name" >= 'test') AS new_name}
-        compile(c <= @table[:comments]).must_be_like %{"users"."name" <= "users"."comments"}
-        compile(c =~ /\Atest\Z/).must_be_like %{REGEXP_LIKE("users"."name", '^test$')}
-        compile(c =~ /\Atest\z/).must_be_like %{REGEXP_LIKE("users"."name", '^test$')}
-        compile(c =~ '^test$').must_be_like %{REGEXP_LIKE("users"."name", '^test$')}
-        compile(c !~ /\Ate\Dst\Z/).must_be_like %{NOT REGEXP_LIKE("users"."name", '^te[^0-9]st$')}
-        compile(c.imatches('%test%')).must_be_like %{LOWER("users"."name") LIKE LOWER('%test%')}
-        compile(c.imatches_any(['%test%', 't2'])).must_be_like %{((LOWER("users"."name") LIKE LOWER('%test%')) OR (LOWER("users"."name") LIKE LOWER('t2')))}
-        compile(c.idoes_not_match('%test%')).must_be_like %{LOWER("users"."name") NOT LIKE LOWER('%test%')}
+        _(compile(c == 'test')).must_be_like %{"users"."name" = 'test'}
+        _(compile(c != 'test')).must_be_like %{"users"."name" != 'test'}
+        _(compile(c > 'test')).must_be_like %{"users"."name" > 'test'}
+        _(compile((c >= 'test').as('new_name'))).must_be_like %{("users"."name" >= 'test') AS new_name}
+        _(compile(c <= @table[:comments])).must_be_like %{"users"."name" <= "users"."comments"}
+        _(compile(c =~ /\Atest\Z/)).must_be_like %{REGEXP_LIKE("users"."name", '^test$')}
+        _(compile(c =~ /\Atest\z/)).must_be_like %{REGEXP_LIKE("users"."name", '^test$')}
+        _(compile(c =~ '^test$')).must_be_like %{REGEXP_LIKE("users"."name", '^test$')}
+        _(compile(c !~ /\Ate\Dst\Z/)).must_be_like %{NOT REGEXP_LIKE("users"."name", '^te[^0-9]st$')}
+        _(compile(c.imatches('%test%'))).must_be_like %{LOWER("users"."name") LIKE LOWER('%test%')}
+        _(compile(c.imatches_any(['%test%', 't2']))).must_be_like %{((LOWER("users"."name") LIKE LOWER('%test%')) OR (LOWER("users"."name") LIKE LOWER('t2')))}
+        _(compile(c.idoes_not_match('%test%'))).must_be_like %{LOWER("users"."name") NOT LIKE LOWER('%test%')}
       end
 
       # Maths
       # DateDiff
       it "should diff date col and date" do
-        compile(@table[:created_at] - Date.new(2016, 3, 31)).must_match %{"users"."created_at" - TO_DATE('2016-03-31')}
+        _(compile(@table[:created_at] - Date.new(2016, 3, 31))).must_match %{"users"."created_at" - TO_DATE('2016-03-31')}
       end
 
       it "should diff date col and datetime col" do
-        compile(@table[:created_at] - @table[:updated_at]).must_match %{"users"."created_at" - "users"."updated_at"}
+        _(compile(@table[:created_at] - @table[:updated_at])).must_match %{"users"."created_at" - "users"."updated_at"}
       end
 
       it "should diff date col and datetime col with AS" do
         sql = compile((@table[:updated_at] - @table[:created_at]).as('new_name'))
 #        sql.must_be_like %{(TO_DATE("users"."updated_at") - "users"."created_at") * 86400 AS new_name}
-        sql.must_be_like %{("users"."updated_at" - "users"."created_at") * (CASE WHEN (TRUNC("users"."updated_at", 'DDD') = "users"."updated_at") THEN 1 ELSE 86400 END) AS new_name}
+        _(sql).must_be_like %{("users"."updated_at" - "users"."created_at") * (CASE WHEN (TRUNC("users"."updated_at", 'DDD') = "users"."updated_at") THEN 1 ELSE 86400 END) AS new_name}
       end
 
       it "should diff between time values" do
         d2 = Time.new(2015,6,1)
         d1 = DateTime.new(2015,6,2)
-        sql = compile(ArelExtensions::Nodes::DateDiff.new([d1,d2]))
-        sql.must_match("TO_DATE('2015-06-02') - TO_DATE('2015-06-01')")
+        _(compile(ArelExtensions::Nodes::DateDiff.new([d1,d2])))
+          .must_match("TO_DATE('2015-06-02') - TO_DATE('2015-06-01')")
       end
 
       it "should diff between time values and time col" do
         d1 = DateTime.new(2015,6,2)
-        sql = compile(ArelExtensions::Nodes::DateDiff.new([d1, @table[:updated_at]]))
-        sql.must_match %{TO_DATE('2015-06-02') - "users"."updated_at"}
+        _(compile(ArelExtensions::Nodes::DateDiff.new([d1, @table[:updated_at]])))
+          .must_match %{TO_DATE('2015-06-02') - "users"."updated_at"}
       end
 
       it "should accept operators on dates with numbers" do
         c = @table[:created_at]
-        compile(c - 42).must_be_like %{DATE_SUB("users"."created_at", 42)}
-        compile(c - @table[:id]).must_be_like %{DATE_SUB("users"."created_at", "users"."id")}
+        _(compile(c - 42)).must_be_like %{DATE_SUB("users"."created_at", 42)}
+        _(compile(c - @table[:id])).must_be_like %{DATE_SUB("users"."created_at", "users"."id")}
       end
 
       # Maths on sums
       it "should accept math operators on anything" do
         c = @table[:name]
-        (c == 'test').to_sql.must_be_like %{"users"."name" = 'test'}
-        (c != 'test').to_sql.must_be_like %{"users"."name" != 'test'}
-        (c > 'test').to_sql.must_be_like %{"users"."name" > 'test'}
-        compile((c >= 'test').as('new_name')).must_be_like %{("users"."name" >= 'test') AS new_name}
-        compile(c <= @table[:comments]).must_be_like %{"users"."name" <= "users"."comments"}
-        compile(c =~ /\Atest\Z/).must_be_like %{REGEXP_LIKE("users"."name", '^test$')}
-        compile(c !~ /\Ate\Dst\Z/).must_be_like %{NOT REGEXP_LIKE("users"."name", '^te[^0-9]st$')}
+        _((c == 'test').to_sql).must_be_like %{"users"."name" = 'test'}
+        _((c != 'test').to_sql).must_be_like %{"users"."name" != 'test'}
+        _((c > 'test').to_sql).must_be_like %{"users"."name" > 'test'}
+        _(compile((c >= 'test').as('new_name'))).must_be_like %{("users"."name" >= 'test') AS new_name}
+        _(compile(c <= @table[:comments])).must_be_like %{"users"."name" <= "users"."comments"}
+        _(compile(c =~ /\Atest\Z/)).must_be_like %{REGEXP_LIKE("users"."name", '^test$')}
+        _(compile(c !~ /\Ate\Dst\Z/)).must_be_like %{NOT REGEXP_LIKE("users"."name", '^te[^0-9]st$')}
       end
 
     end

--- a/test/visitors/test_to_sql.rb
+++ b/test/visitors/test_to_sql.rb
@@ -24,375 +24,379 @@ module ArelExtensions
 
       # Math Functions
       it "should not break Arel functions" do
-        compile(@price + 42).must_be_like %{("products"."price" + 42)}
-        compile(@table[:id] + @table[:pas_en_base])
+        _(compile(@price + 42)).must_be_like %{("products"."price" + 42)}
+        _(compile(@table[:id] + @table[:pas_en_base]))
           .must_be_like %{("users"."id" + "users"."pas_en_base")}
-        compile(@table[:pas_en_base] + @table[:id])
+        _(compile(@table[:pas_en_base] + @table[:id]))
           .must_be_like %{("users"."pas_en_base" + "users"."id")}
-        compile(@table[:id] - @table[:pas_en_base])
+        _(compile(@table[:id] - @table[:pas_en_base]))
           .must_be_like %{("users"."id" - "users"."pas_en_base")}
-        compile(@table[:pas_en_base] - @table[:id])
+        _(compile(@table[:pas_en_base] - @table[:id]))
           .must_be_like %{("users"."pas_en_base" - "users"."id")}
-        compile(@table[:id] * @table[:pas_en_base])
+        _(compile(@table[:id] * @table[:pas_en_base]))
           .must_be_like %{"users"."id" * "users"."pas_en_base"}
-        compile(@table[:pas_en_base] * @table[:id])
+        _(compile(@table[:pas_en_base] * @table[:id]))
           .must_be_like %{"users"."pas_en_base" * "users"."id"}
       end
 
       it "should return right calculations on numbers" do
         #puts (@price.abs + 42).inspect
-        compile(@price.abs + 42).must_be_like %{(ABS("products"."price") + 42)}
-        compile(@price.ceil + 42).must_be_like %{(CEIL("products"."price") + 42)}
-        compile(@price.floor + 42).must_be_like %{(FLOOR("products"."price") + 42)}
-        compile(@price.log10 + 42).must_be_like %{(LOG10("products"."price") + 42)}
-        compile(@price.power(42) + 42).must_be_like %{(POW("products"."price", 42) + 42)}
-        compile(@price.pow(42) + 42).must_be_like %{(POW("products"."price", 42) + 42)}
-        compile(@price.ceil + @price.floor).must_be_like %{(CEIL("products"."price") + FLOOR("products"."price"))}
-        compile((@price.ceil + @price.floor).abs).must_be_like %{ABS((CEIL("products"."price") + FLOOR("products"."price")))}
-        compile(@price.round + 42).must_be_like %{(ROUND("products"."price") + 42)}
-        compile(@price.round(2) + 42).must_be_like %{(ROUND("products"."price", 2) + 42)}
-        compile(Arel.rand + 42).must_be_like %{(RAND() + 42)}
-        compile(@price.sum + 42).must_be_like %{(SUM("products"."price") + 42)}
-        compile((@price + 42).sum).must_be_like %{SUM(("products"."price" + 42))}
-        compile((@price + 42).average).must_be_like %{AVG(("products"."price" + 42))}
-        compile((Arel.rand * 9).round + 42).must_be_like %{(ROUND(RAND() * 9) + 42)}
-        compile((Arel.rand * @price).round(2) + @price).must_be_like %{(ROUND(RAND() * "products"."price", 2) + "products"."price")}
+        _(compile(@price.abs + 42)).must_be_like %{(ABS("products"."price") + 42)}
+        _(compile(@price.ceil + 42)).must_be_like %{(CEIL("products"."price") + 42)}
+        _(compile(@price.floor + 42)).must_be_like %{(FLOOR("products"."price") + 42)}
+        _(compile(@price.log10 + 42)).must_be_like %{(LOG10("products"."price") + 42)}
+        _(compile(@price.power(42) + 42)).must_be_like %{(POW("products"."price", 42) + 42)}
+        _(compile(@price.pow(42) + 42)).must_be_like %{(POW("products"."price", 42) + 42)}
+        _(compile(@price.ceil + @price.floor)).must_be_like %{(CEIL("products"."price") + FLOOR("products"."price"))}
+        _(compile((@price.ceil + @price.floor).abs)).must_be_like %{ABS((CEIL("products"."price") + FLOOR("products"."price")))}
+        _(compile(@price.round + 42)).must_be_like %{(ROUND("products"."price") + 42)}
+        _(compile(@price.round(2) + 42)).must_be_like %{(ROUND("products"."price", 2) + 42)}
+        _(compile(Arel.rand + 42)).must_be_like %{(RAND() + 42)}
+        _(compile(@price.sum + 42)).must_be_like %{(SUM("products"."price") + 42)}
+        _(compile((@price + 42).sum)).must_be_like %{SUM(("products"."price" + 42))}
+        _(compile((@price + 42).average)).must_be_like %{AVG(("products"."price" + 42))}
+        _(compile((Arel.rand * 9).round + 42)).must_be_like %{(ROUND(RAND() * 9) + 42)}
+        _(compile((Arel.rand * @price).round(2) + @price)).must_be_like %{(ROUND(RAND() * "products"."price", 2) + "products"."price")}
 
-        compile(@price.std + 42).must_be_like %{(STD("products"."price") + 42)}
-        compile(@price.variance + 42).must_be_like %{(VARIANCE("products"."price") + 42)}
+        _(compile(@price.std + 42)).must_be_like %{(STD("products"."price") + 42)}
+        _(compile(@price.variance + 42)).must_be_like %{(VARIANCE("products"."price") + 42)}
 
-        compile(@price.coalesce(0) - 42).must_be_like %{(COALESCE("products"."price", 0) - 42)}
-        compile(@price.sum - 42).must_be_like %{(SUM("products"."price") - 42)}
-        compile(@price.std - 42).must_be_like %{(STD("products"."price") - 42)}
-        compile(@price.variance - 42).must_be_like %{(VARIANCE("products"."price") - 42)}
+        _(compile(@price.coalesce(0) - 42)).must_be_like %{(COALESCE("products"."price", 0) - 42)}
+        _(compile(@price.sum - 42)).must_be_like %{(SUM("products"."price") - 42)}
+        _(compile(@price.std - 42)).must_be_like %{(STD("products"."price") - 42)}
+        _(compile(@price.variance - 42)).must_be_like %{(VARIANCE("products"."price") - 42)}
 
-        compile(@price * 42.0).must_be_like %{"products"."price" * 42.0}
-        compile(@price / 42.0).must_be_like %{"products"."price" / 42.0}
+        _(compile(@price * 42.0)).must_be_like %{"products"."price" * 42.0}
+        _(compile(@price / 42.0)).must_be_like %{"products"."price" / 42.0}
 
         fake_table = Arel::Table.new('fake_tables')
 
-        compile(fake_table[:fake_att] - 42).must_be_like %{("fake_tables"."fake_att" - 42)}
-        compile(fake_table[:fake_att].coalesce(0) - 42).must_be_like %{(COALESCE("fake_tables"."fake_att", 0) - 42)}
+        _(compile(fake_table[:fake_att] - 42)).must_be_like %{("fake_tables"."fake_att" - 42)}
+        _(compile(fake_table[:fake_att].coalesce(0) - 42)).must_be_like %{(COALESCE("fake_tables"."fake_att", 0) - 42)}
       end
 
       # String Functions
       it "should accept functions on strings" do
         c = @table[:name]
-        compile(c + 'test').must_be_like %{CONCAT(\"users\".\"name\", 'test')}
-        compile(c.length).must_be_like %{LENGTH("users"."name")}
+        _(compile(c + 'test')).must_be_like %{CONCAT(\"users\".\"name\", 'test')}
+        _(compile(c.length)).must_be_like %{LENGTH("users"."name")}
         #puts (c.length.round + 42).inspect
-        compile(c.length.round + 42).must_be_like %{(ROUND(LENGTH("users"."name")) + 42)}
-        compile(c.locate('test')).must_be_like %{LOCATE('test', "users"."name")}
-        compile(c & 42).must_be_like %{FIND_IN_SET(42, "users"."name")}
+        _(compile(c.length.round + 42)).must_be_like %{(ROUND(LENGTH("users"."name")) + 42)}
+        _(compile(c.locate('test'))).must_be_like %{LOCATE('test', "users"."name")}
+        _(compile(c & 42)).must_be_like %{FIND_IN_SET(42, "users"."name")}
 
-        compile((c >= 'test').as('new_name')).must_be_like %{("users"."name" >= 'test') AS new_name}
-        compile(c <= @table[:comments]).must_be_like %{"users"."name" <= "users"."comments"}
-        compile(c =~ /\Atest\Z/).must_be_like %{"users"."name" REGEXP '^test$'}
-        compile(c =~ /\Atest\z/).must_be_like %{"users"."name" REGEXP '^test$'}
-        compile(c !~ /\Ate\Dst\Z/).must_be_like %{"users"."name" NOT REGEXP '^te[^0-9]st$'}
-        compile(c.imatches('%test%')).must_be_like %{"users"."name" ILIKE '%test%'}
-        compile(c.imatches_any(['%test%', 't2'])).must_be_like %{(("users"."name" ILIKE '%test%') OR ("users"."name" ILIKE 't2'))}
-        compile(c.idoes_not_match('%test%')).must_be_like %{"users"."name" NOT ILIKE '%test%'}
+        _(compile((c >= 'test').as('new_name'))).must_be_like %{("users"."name" >= 'test') AS new_name}
+        _(compile(c <= @table[:comments])).must_be_like %{"users"."name" <= "users"."comments"}
+        _(compile(c =~ /\Atest\Z/)).must_be_like %{"users"."name" REGEXP '^test$'}
+        _(compile(c =~ /\Atest\z/)).must_be_like %{"users"."name" REGEXP '^test$'}
+        _(compile(c !~ /\Ate\Dst\Z/)).must_be_like %{"users"."name" NOT REGEXP '^te[^0-9]st$'}
+        _(compile(c.imatches('%test%'))).must_be_like %{"users"."name" ILIKE '%test%'}
+        _(compile(c.imatches_any(['%test%', 't2']))).must_be_like %{(("users"."name" ILIKE '%test%') OR ("users"."name" ILIKE 't2'))}
+        _(compile(c.idoes_not_match('%test%'))).must_be_like %{"users"."name" NOT ILIKE '%test%'}
 
-        compile(c.substring(1)).must_be_like %{SUBSTRING("users"."name", 1)}
-        compile(c + '0').must_be_like %{CONCAT("users"."name", '0')}
-        compile(c.substring(1) + '0').must_be_like %{CONCAT(SUBSTRING("users"."name", 1), '0')}
-        compile(c.substring(1) + c.substring(2)).must_be_like %{CONCAT(SUBSTRING("users"."name", 1), SUBSTRING("users"."name", 2))}
-        compile(c.concat(c).concat(c)).must_be_like %{CONCAT("users"."name", "users"."name", "users"."name")}
-        compile(c + c + c).must_be_like %{CONCAT("users"."name", "users"."name", "users"."name")}
+        _(compile(c.substring(1))).must_be_like %{SUBSTRING("users"."name", 1)}
+        _(compile(c + '0')).must_be_like %{CONCAT("users"."name", '0')}
+        _(compile(c.substring(1) + '0')).must_be_like %{CONCAT(SUBSTRING("users"."name", 1), '0')}
+        _(compile(c.substring(1) + c.substring(2))).must_be_like %{CONCAT(SUBSTRING("users"."name", 1), SUBSTRING("users"."name", 2))}
+        _(compile(c.concat(c).concat(c))).must_be_like %{CONCAT("users"."name", "users"."name", "users"."name")}
+        _(compile(c + c + c)).must_be_like %{CONCAT("users"."name", "users"."name", "users"."name")}
 
         # some optimization on concat
-        compile(c + 'test' + ' chain').must_be_like %{CONCAT(\"users\".\"name\", 'test chain')}
-        compile(Arel::Nodes.build_quoted('test') + ' chain').must_be_like %{'test chain'}
-        compile(c + '' + c).must_be_like %{CONCAT(\"users\".\"name\", \"users\".\"name\")}
+        _(compile(c + 'test' + ' chain')).must_be_like %{CONCAT(\"users\".\"name\", 'test chain')}
+        _(compile(Arel::Nodes.build_quoted('test') + ' chain')).must_be_like %{'test chain'}
+        _(compile(c + '' + c)).must_be_like %{CONCAT(\"users\".\"name\", \"users\".\"name\")}
 
-        compile(c.md5).must_be_like  %{MD5(\"users\".\"name\")}
+        _(compile(c.md5)).must_be_like  %{MD5(\"users\".\"name\")}
       end
 
       # Comparators
 
       it "should accept comparators on integers" do
-        compile(@table[:id] == 42).must_match %{"users"."id" = 42}
-        compile(@table[:id] == @table[:id]).must_be_like %{"users"."id" = "users"."id"}
-        compile(@table[:id] != 42).must_match %{"users"."id" != 42}
-        compile(@table[:id] > 42).must_match %{"users"."id" > 42}
-        compile(@table[:id] >= 42).must_match %{"users"."id" >= 42}
-        compile(@table[:id] >= @table[:id]).must_be_like %{"users"."id" >= "users"."id"}
-        compile(@table[:id] < 42).must_match %{"users"."id" < 42}
-        compile(@table[:id] <= 42).must_match %{"users"."id" <= 42}
-        compile((@table[:id] <= 42).as('new_name')).must_match %{("users"."id" <= 42) AS new_name}
-        compile(@table[:id].count.eq 42).must_match %{COUNT("users"."id") = 42}
-        #compile(@table[:id].count == 42).must_match %{COUNT("users"."id") = 42} # TODO
-        #compile(@table[:id].count != 42).must_match %{COUNT("users"."id") != 42}
-        #compile(@table[:id].count >= 42).must_match %{COUNT("users"."id") >= 42}
+        _(compile(@table[:id] == 42)).must_match %{"users"."id" = 42}
+        _(compile(@table[:id] == @table[:id])).must_be_like %{"users"."id" = "users"."id"}
+        _(compile(@table[:id] != 42)).must_match %{"users"."id" != 42}
+        _(compile(@table[:id] > 42)).must_match %{"users"."id" > 42}
+        _(compile(@table[:id] >= 42)).must_match %{"users"."id" >= 42}
+        _(compile(@table[:id] >= @table[:id])).must_be_like %{"users"."id" >= "users"."id"}
+        _(compile(@table[:id] < 42)).must_match %{"users"."id" < 42}
+        _(compile(@table[:id] <= 42)).must_match %{"users"."id" <= 42}
+        _(compile((@table[:id] <= 42).as('new_name'))).must_match %{("users"."id" <= 42) AS new_name}
+        _(compile(@table[:id].count.eq 42)).must_match %{COUNT("users"."id") = 42}
+        #_(compile(@table[:id].count == 42)).must_match %{COUNT("users"."id") = 42} # TODO
+        #_(compile(@table[:id].count != 42)).must_match %{COUNT("users"."id") != 42}
+        #_(compile(@table[:id].count >= 42)).must_match %{COUNT("users"."id") >= 42}
       end
 
       it "should accept comparators on dates" do
         c = @table[:created_at]
         u = @table[:updated_at]
-        compile(c > @date).must_be_like %{"users"."created_at" > '2016-03-31'}
-        compile(u >= @date).must_be_like %{"users"."updated_at" >= '2016-03-31'}
-        compile(c < u).must_be_like %{"users"."created_at" < "users"."updated_at"}
+        _(compile(c > @date)).must_be_like %{"users"."created_at" > '2016-03-31'}
+        _(compile(u >= @date)).must_be_like %{"users"."updated_at" >= '2016-03-31'}
+        _(compile(c < u)).must_be_like %{"users"."created_at" < "users"."updated_at"}
       end
 
       it "should accept comparators on strings" do
         c = @table[:name]
-        compile(c == 'test').must_be_like %{"users"."name" = 'test'}
-        compile(c != 'test').must_be_like %{"users"."name" != 'test'}
-        compile(c > 'test').must_be_like %{"users"."name" > 'test'}
-        compile((c >= 'test').as('new_name')).must_be_like %{("users"."name" >= 'test') AS new_name}
-        compile(c <= @table[:comments]).must_be_like %{"users"."name" <= "users"."comments"}
-        compile(c =~ /\Atest\Z/).must_be_like %{"users"."name" REGEXP '^test$'}
-        compile(c !~ /\Ate\Dst\Z/).must_be_like %{"users"."name" NOT REGEXP '^te[^0-9]st$'}
-        compile(c.imatches('%test%')).must_be_like %{"users"."name" ILIKE '%test%'}
-        compile(c.imatches_any(['%test%', 't2'])).must_be_like %{(("users"."name" ILIKE '%test%') OR ("users"."name" ILIKE 't2'))}
-        compile(c.idoes_not_match('%test%')).must_be_like %{"users"."name" NOT ILIKE '%test%'}
+        _(compile(c == 'test')).must_be_like %{"users"."name" = 'test'}
+        _(compile(c != 'test')).must_be_like %{"users"."name" != 'test'}
+        _(compile(c > 'test')).must_be_like %{"users"."name" > 'test'}
+        _(compile((c >= 'test').as('new_name'))).must_be_like %{("users"."name" >= 'test') AS new_name}
+        _(compile(c <= @table[:comments])).must_be_like %{"users"."name" <= "users"."comments"}
+        _(compile(c =~ /\Atest\Z/)).must_be_like %{"users"."name" REGEXP '^test$'}
+        _(compile(c !~ /\Ate\Dst\Z/)).must_be_like %{"users"."name" NOT REGEXP '^te[^0-9]st$'}
+        _(compile(c.imatches('%test%'))).must_be_like %{"users"."name" ILIKE '%test%'}
+        _(compile(c.imatches_any(['%test%', 't2']))).must_be_like %{(("users"."name" ILIKE '%test%') OR ("users"."name" ILIKE 't2'))}
+        _(compile(c.idoes_not_match('%test%'))).must_be_like %{"users"."name" NOT ILIKE '%test%'}
       end
 
       # Maths
       # DateDiff
       it "should diff date col and date" do
-        compile(@table[:created_at] - Date.new(2016, 3, 31)).must_match %{DATEDIFF("users"."created_at", '2016-03-31')}
+        _(compile(@table[:created_at] - Date.new(2016, 3, 31))).must_match %{DATEDIFF("users"."created_at", '2016-03-31')}
       end
 
       it "should diff date col and datetime col" do
-        compile(@table[:created_at] - @table[:updated_at]).must_match %{DATEDIFF("users"."created_at", "users"."updated_at")}
+        _(compile(@table[:created_at] - @table[:updated_at])).must_match %{DATEDIFF("users"."created_at", "users"."updated_at")}
       end
 
       it "should diff date col and datetime col with AS" do
-        sql = compile((@table[:updated_at] - @table[:created_at]).as('new_name'))
-        sql.must_match %{TIMEDIFF("users"."updated_at", "users"."created_at") AS new_name}
+        _(compile((@table[:updated_at] - @table[:created_at]).as('new_name')))
+          .must_match %{TIMEDIFF("users"."updated_at", "users"."created_at") AS new_name}
       end
 
       it "should diff between time values" do
         d2 = Time.new(2015,6,1)
         d1 = DateTime.new(2015,6,2)
-        sql = compile(ArelExtensions::Nodes::DateDiff.new([d1, d2]))
-        sql.must_match("DATEDIFF('2015-06-02', '2015-06-01')")
+        _(compile(ArelExtensions::Nodes::DateDiff.new([d1, d2])))
+          .must_match("DATEDIFF('2015-06-02', '2015-06-01')")
       end
 
       it "should diff between time values and time col" do
         d1 = DateTime.new(2015,6,2)
-        sql = compile(ArelExtensions::Nodes::DateDiff.new([d1, @table[:updated_at]]))
-        sql.must_match %{DATEDIFF('2015-06-02', "users"."updated_at")}
+        _(compile(ArelExtensions::Nodes::DateDiff.new([d1, @table[:updated_at]])))
+          .must_match %{DATEDIFF('2015-06-02', "users"."updated_at")}
       end
 
       it "should diff between date col and duration" do
         d1 = 10
         d2 = -10
-        compile(@table[:created_at] - d1).
-          must_match %{DATE_SUB("users"."created_at", 10)}
-        compile(@table[:created_at] - d2).
-          must_match %{DATE_SUB("users"."created_at", -10)}
+        _(compile(@table[:created_at] - d1))
+          .must_match %{DATE_SUB("users"."created_at", 10)}
+        _(compile(@table[:created_at] - d2))
+          .must_match %{DATE_SUB("users"."created_at", -10)}
       end
 
       it "should accept operators on dates with numbers" do
         c = @table[:created_at]
         #u = @table[:updated_at]
-        compile(c - 42).must_be_like %{DATE_SUB("users"."created_at", 42)}
-        compile(c - @table[:id]).must_be_like %{DATE_SUB("users"."created_at", "users"."id")}
+        _(compile(c - 42)).must_be_like %{DATE_SUB("users"."created_at", 42)}
+        _(compile(c - @table[:id])).must_be_like %{DATE_SUB("users"."created_at", "users"."id")}
       end
 
       # Maths on sums
       it "should accept math operators on anything" do
         c = @table[:name]
-        (c == 'test').to_sql.must_be_like %{"users"."name" = 'test'}
-        (c != 'test').to_sql.must_be_like %{"users"."name" != 'test'}
-        (c > 'test').to_sql.must_be_like %{"users"."name" > 'test'}
-        compile((c >= 'test').as('new_name')).must_be_like %{("users"."name" >= 'test') AS new_name}
-        compile(c <= @table[:comments]).must_be_like %{"users"."name" <= "users"."comments"}
-        compile(c =~ /\Atest\Z/).must_be_like %{"users"."name" REGEXP '^test$'}
-        compile(c !~ /\Ate\Dst\Z/).must_be_like %{"users"."name" NOT REGEXP '^te[^0-9]st$'}
+        _((c == 'test').to_sql)
+          .must_be_like %{"users"."name" = 'test'}
+        _((c != 'test').to_sql)
+          .must_be_like %{"users"."name" != 'test'}
+        _((c > 'test').to_sql)
+          .must_be_like %{"users"."name" > 'test'}
+        _(compile((c >= 'test').as('new_name'))).must_be_like %{("users"."name" >= 'test') AS new_name}
+        _(compile(c <= @table[:comments])).must_be_like %{"users"."name" <= "users"."comments"}
+        _(compile(c =~ /\Atest\Z/)).must_be_like %{"users"."name" REGEXP '^test$'}
+        _(compile(c !~ /\Ate\Dst\Z/)).must_be_like %{"users"."name" NOT REGEXP '^te[^0-9]st$'}
       end
 
       it "should manage complex formulas" do
         c = @table[:name]
-        compile(
-          (c.length / 42).round(2).floor > (@table[:updated_at] - Date.new(2000, 3, 31)).abs.ceil
-        ).must_be_like %{FLOOR(ROUND(LENGTH("users"."name") / 42, 2)) > CEIL(ABS(TIMEDIFF("users"."updated_at", '2000-03-31 00:00:00 UTC')))}
+        _(compile(
+            (c.length / 42).round(2).floor > (@table[:updated_at] - Date.new(2000, 3, 31)).abs.ceil
+          ))
+          .must_be_like %{FLOOR(ROUND(LENGTH("users"."name") / 42, 2)) > CEIL(ABS(TIMEDIFF("users"."updated_at", '2000-03-31 00:00:00 UTC')))}
       end
 
       it "should accept aggregator like GROUP CONCAT" do
-        @table.project(@table[:first_name].group_concat).group(@table[:last_name]).to_sql
+        _(@table.project(@table[:first_name].group_concat).group(@table[:last_name]).to_sql)
           .must_be_like %{SELECT GROUP_CONCAT("users"."first_name") FROM "users" GROUP BY "users"."last_name"}
-        @table.project(@table[:first_name].group_concat('++')).group(@table[:last_name]).to_sql
+        _(@table.project(@table[:first_name].group_concat('++')).group(@table[:last_name]).to_sql)
           .must_be_like %{SELECT GROUP_CONCAT("users"."first_name", '++') FROM "users" GROUP BY "users"."last_name"}
       end
 
       # Unions
       it "should accept union operators on queries and union nodes" do
         c = @table.project(@table[:name])
-        compile(c + c)
+        _(compile(c + c))
           .must_be_like %{(SELECT "users"."name" FROM "users") UNION (SELECT "users"."name" FROM "users")}
-        (c + c).to_sql
+        _((c + c).to_sql)
           .must_be_like %{(SELECT "users"."name" FROM "users") UNION (SELECT "users"."name" FROM "users")}
-        (c + (c + c)).to_sql
+        _((c + (c + c)).to_sql)
           .must_be_like %{(SELECT "users"."name" FROM "users") UNION (SELECT "users"."name" FROM "users") UNION (SELECT "users"."name" FROM "users")}
-        ((c + c) + c).to_sql
+        _(((c + c) + c).to_sql)
           .must_be_like %{(SELECT "users"."name" FROM "users") UNION (SELECT "users"."name" FROM "users") UNION (SELECT "users"."name" FROM "users")}
-        (c + c + c).to_sql
+        _((c + c + c).to_sql)
           .must_be_like %{(SELECT "users"."name" FROM "users") UNION (SELECT "users"."name" FROM "users") UNION (SELECT "users"."name" FROM "users")}
-        (c + c).as('union_table').to_sql
+        _((c + c).as('union_table').to_sql)
           .must_be_like %{((SELECT "users"."name" FROM "users") UNION (SELECT "users"."name" FROM "users")) union_table}
         c = @table.project(@table[:name])
-        compile(c.union_all(c))
+        _(compile(c.union_all(c)))
           .must_be_like %{(SELECT "users"."name" FROM "users") UNION ALL (SELECT "users"."name" FROM "users")}
-        (c.union_all(c)).to_sql
+        _((c.union_all(c)).to_sql)
           .must_be_like %{(SELECT "users"."name" FROM "users") UNION ALL (SELECT "users"."name" FROM "users")}
-        (c.union_all(c.union_all(c))).to_sql
+        _((c.union_all(c.union_all(c))).to_sql)
           .must_be_like %{(SELECT "users"."name" FROM "users") UNION ALL (SELECT "users"."name" FROM "users") UNION ALL (SELECT "users"."name" FROM "users")}
-        ((c.union_all(c)).union_all(c)).to_sql
+        _(((c.union_all(c)).union_all(c)).to_sql)
           .must_be_like %{(SELECT "users"."name" FROM "users") UNION ALL (SELECT "users"."name" FROM "users") UNION ALL (SELECT "users"."name" FROM "users")}
-        (c.union_all(c).union_all(c)).to_sql
+        _((c.union_all(c).union_all(c)).to_sql)
           .must_be_like %{(SELECT "users"."name" FROM "users") UNION ALL (SELECT "users"."name" FROM "users") UNION ALL (SELECT "users"."name" FROM "users")}
-        (c.union_all(c)).as('union_table').to_sql
+        _((c.union_all(c)).as('union_table').to_sql)
           .must_be_like %{((SELECT "users"."name" FROM "users") UNION ALL (SELECT "users"."name" FROM "users")) union_table}
       end
 
       # Case
       it "should accept case clause" do
-        @table[:name].when("smith").then("cool").when("doe").then("fine").else("uncool").to_sql
+        _(@table[:name].when("smith").then("cool").when("doe").then("fine").else("uncool").to_sql)
           .must_be_like %{CASE "users"."name" WHEN 'smith' THEN 'cool' WHEN 'doe' THEN 'fine' ELSE 'uncool' END}
-        @table[:name].when("smith").then(1).when("doe").then(2).else(0).to_sql
+        _(@table[:name].when("smith").then(1).when("doe").then(2).else(0).to_sql)
           .must_be_like %{CASE "users"."name" WHEN 'smith' THEN 1 WHEN 'doe' THEN 2 ELSE 0 END}
-        ArelExtensions::Nodes::Case.new.when(@table[:name] == "smith").then(1).when(@table[:name] == "doe").then(2).else(0).to_sql
+        _(ArelExtensions::Nodes::Case.new.when(@table[:name] == "smith").then(1).when(@table[:name] == "doe").then(2).else(0).to_sql)
           .must_be_like %{CASE WHEN "users"."name" = 'smith' THEN 1 WHEN "users"."name" = 'doe' THEN 2 ELSE 0 END}
-        ArelExtensions::Nodes::Case.new(@table[:name]).when("smith").then(1).when("doe").then(2).else(0).to_sql
+        _(ArelExtensions::Nodes::Case.new(@table[:name]).when("smith").then(1).when("doe").then(2).else(0).to_sql)
           .must_be_like %{CASE "users"."name" WHEN 'smith' THEN 1 WHEN 'doe' THEN 2 ELSE 0 END}
-        @table[:name].when("smith").then(1).when("doe").then(2).else(0).sum.to_sql
+        _(@table[:name].when("smith").then(1).when("doe").then(2).else(0).sum.to_sql)
           .must_be_like %{SUM(CASE "users"."name" WHEN 'smith' THEN 1 WHEN 'doe' THEN 2 ELSE 0 END)}
-        @table[:name].when("smith").then("cool").else("uncool").matches('value',false).to_sql
+        _(@table[:name].when("smith").then("cool").else("uncool").matches('value',false).to_sql)
           .must_be_like %{CASE "users"."name" WHEN 'smith' THEN 'cool' ELSE 'uncool' END LIKE 'value'}
-        @table[:name].when("smith").then("cool").else("uncool").imatches('value',false).to_sql
+        _(@table[:name].when("smith").then("cool").else("uncool").imatches('value',false).to_sql)
           .must_be_like %{CASE "users"."name" WHEN 'smith' THEN 'cool' ELSE 'uncool' END ILIKE 'value'}
       end
 
       it "should be possible to use as on anything" do
-        compile(@table[:name].as('alias')).must_be_like %{"users"."name" AS alias}
-        compile(@table[:name].concat(' test').as('alias')).must_be_like %{CONCAT("users"."name", ' test') AS alias}
-        compile((@table[:name] + ' test').as('alias')).must_be_like %{CONCAT("users"."name", ' test') AS alias}
-        compile((@table[:age] + 42).as('alias')).must_be_like %{("users"."age" + 42) AS alias}
-        compile(@table[:name].coalesce('').as('alias')).must_be_like %{COALESCE("users"."name", '') AS alias}
-        compile(Arel::Nodes.build_quoted('test').as('alias')).must_be_like %{'test' AS alias}
-        compile(@table.project(@table[:name]).as('alias')).must_be_like %{(SELECT "users"."name" FROM "users") alias}
-        compile(@table[:name].when("smith").then("cool").else("uncool").as('alias')).
-          must_be_like %{CASE "users"."name" WHEN 'smith' THEN 'cool' ELSE 'uncool' END AS alias}
+        _(compile(@table[:name].as('alias'))).must_be_like %{"users"."name" AS alias}
+        _(compile(@table[:name].concat(' test').as('alias'))).must_be_like %{CONCAT("users"."name", ' test') AS alias}
+        _(compile((@table[:name] + ' test').as('alias'))).must_be_like %{CONCAT("users"."name", ' test') AS alias}
+        _(compile((@table[:age] + 42).as('alias'))).must_be_like %{("users"."age" + 42) AS alias}
+        _(compile(@table[:name].coalesce('').as('alias'))).must_be_like %{COALESCE("users"."name", '') AS alias}
+        _(compile(Arel::Nodes.build_quoted('test').as('alias'))).must_be_like %{'test' AS alias}
+        _(compile(@table.project(@table[:name]).as('alias'))).must_be_like %{(SELECT "users"."name" FROM "users") alias}
+        _(compile(@table[:name].when("smith").then("cool").else("uncool").as('alias')))
+          .must_be_like %{CASE "users"."name" WHEN 'smith' THEN 'cool' ELSE 'uncool' END AS alias}
       end
 
       it "should accept comparators on functions" do
         c = @table[:name]
-        compile(c.soundex == 'test').must_be_like %{SOUNDEX("users"."name") = 'test'}
-        compile(c.soundex != 'test').must_be_like %{SOUNDEX("users"."name") != 'test'}
-        compile(c.length >= 0 ).must_be_like %{LENGTH("users"."name") >= 0}
+        _(compile(c.soundex == 'test')).must_be_like %{SOUNDEX("users"."name") = 'test'}
+        _(compile(c.soundex != 'test')).must_be_like %{SOUNDEX("users"."name") != 'test'}
+        _(compile(c.length >= 0 )).must_be_like %{LENGTH("users"."name") >= 0}
       end
 
       it "should accept in on select statement" do
         c = @table[:name]
-        compile(c.in(@table.project(@table[:name])))
+        _(compile(c.in(@table.project(@table[:name]))))
           .must_be_like %{"users"."name" IN (SELECT "users"."name" FROM "users")}
       end
 
       it "should accept coalesce function properly even on none actual tables and attributes" do
         fake_at = Arel::Table.new('fake_table')
-        compile(fake_at['fake_attribute'].coalesce('other_value'))
+        _(compile(fake_at['fake_attribute'].coalesce('other_value')))
           .must_be_like %{COALESCE("fake_table"."fake_attribute", 'other_value')}
-        compile(fake_at['fake_attribute'].coalesce('other_value1','other_value2'))
+        _(compile(fake_at['fake_attribute'].coalesce('other_value1','other_value2')))
           .must_be_like %{COALESCE("fake_table"."fake_attribute", 'other_value1', 'other_value2')}
-        compile(fake_at['fake_attribute'].coalesce('other_value1').coalesce('other_value2'))
+        _(compile(fake_at['fake_attribute'].coalesce('other_value1').coalesce('other_value2')))
           .must_be_like %{COALESCE(COALESCE("fake_table"."fake_attribute", 'other_value1'), 'other_value2')}
-        compile(fake_at['fake_attribute'].coalesce('other_value').matches('truc'))
+        _(compile(fake_at['fake_attribute'].coalesce('other_value').matches('truc')))
           .must_be_like %{COALESCE("fake_table"."fake_attribute", 'other_value') LIKE 'truc'}
-        compile(fake_at['fake_attribute'].coalesce('other_value').imatches('truc'))
+        _(compile(fake_at['fake_attribute'].coalesce('other_value').imatches('truc')))
           .must_be_like %{COALESCE("fake_table"."fake_attribute", 'other_value') ILIKE 'truc'}
       end
 
       it "should be possible to cast nodes types" do
-        compile(@table[:id].cast('char'))
+        _(compile(@table[:id].cast('char')))
           .must_be_like %{CAST("users"."id" AS char)}
-        compile(@table[:id].coalesce(' ').cast('char'))
+        _(compile(@table[:id].coalesce(' ').cast('char')))
           .must_be_like %{CAST(COALESCE("users"."id", ' ') AS char)}
-        compile(@table[:id].coalesce(' ').cast(:string))
+        _(compile(@table[:id].coalesce(' ').cast(:string)))
           .must_be_like %{CAST(COALESCE("users"."id", ' ') AS char)}
-        compile(@table[:id].cast(:string).coalesce(' '))
+        _(compile(@table[:id].cast(:string).coalesce(' ')))
           .must_be_like %{COALESCE(CAST(\"users\".\"id\" AS char), ' ')}
-        compile(@table[:id].cast('char') + ' ')
+        _(compile(@table[:id].cast('char') + ' '))
           .must_be_like %{CONCAT(CAST("users"."id" AS char), ' ')}
-        compile(@table[:id].cast('int') + 2)
+        _(compile(@table[:id].cast('int') + 2))
           .must_be_like %{(CAST("users"."id" AS int) + 2)}
       end
 
       it "should be possible to have nil element in the function NIL" do
-        compile(@table[:id].in(nil))
+        _(compile(@table[:id].in(nil)))
           .must_be_like %{ISNULL("users"."id")}
-        compile(@table[:id].in([nil]))
+        _(compile(@table[:id].in([nil])))
           .must_be_like %{ISNULL("users"."id")}
-        compile(@table[:id].in([nil,1]))
+        _(compile(@table[:id].in([nil,1])))
           .must_be_like %{(ISNULL("users"."id")) OR ("users"."id" = 1)}
-        compile(@table[:id].in([nil,1,2]))
+        _(compile(@table[:id].in([nil,1,2])))
           .must_be_like %{(ISNULL("users"."id")) OR ("users"."id" IN (1, 2))}
-        compile(@table[:id].in(1))
+        _(compile(@table[:id].in(1)))
           .must_be_like %{"users"."id" IN (1)}
-        compile(@table[:id].in([1]))
+        _(compile(@table[:id].in([1])))
           .must_be_like %{"users"."id" = 1}
-        compile(@table[:id].in([1,2]))
+        _(compile(@table[:id].in([1,2])))
           .must_be_like %{"users"."id" IN (1, 2)}
       end
 
       it "should be possible to correctly use a Range on an IN" do
-        compile(@table[:id].in(1..4))
+        _(compile(@table[:id].in(1..4)))
           .must_be_like %{"users"."id" BETWEEN (1) AND (4)}
-        compile(@table[:created_at].in(@date .. Date.new(2017, 3, 31))) # @date = Date.new(2016, 3, 31)
+        _(compile(@table[:created_at].in(@date .. Date.new(2017, 3, 31)))) # @date = Date.new(2016, 3, 31)
           .must_be_like %{"users"."created_at" BETWEEN ('2016-03-31') AND ('2017-03-31')}
       end
 
       it "should be possible to use a list of values and ranges on an IN" do
-        compile(@table[:id].in [1..10, 20, 30, 40..50])
+        _(compile(@table[:id].in [1..10, 20, 30, 40..50]))
           .must_be_like %{(("users"."id" IN (20, 30)) OR ("users"."id" BETWEEN (1) AND (10))) OR ("users"."id" BETWEEN (40) AND (50))}
-#        compile(@table[:created_at].in(@date .. Date.new(2017, 3, 31))) # @date = Date.new(2016, 3, 31)
+#        _(compile(@table[:created_at].in(@date .. Date.new(2017, 3, 31)))) # @date = Date.new(2016, 3, 31)
 #          .must_be_like %{"users"."created_at" BETWEEN ('2016-03-31') AND ('2017-03-31')}
       end
 
       it "should be possible to add and substract as much as we want" do
         c = @table[:name]
-        compile(c.locate('test')+1)
+        _(compile(c.locate('test')+1))
           .must_be_like %{(LOCATE('test', "users"."name") + 1)}
-        compile(c.locate('test')-1)
+        _(compile(c.locate('test')-1))
           .must_be_like %{(LOCATE('test', "users"."name") - 1)}
-        compile(c.locate('test')+c.locate('test'))
+        _(compile(c.locate('test')+c.locate('test')))
           .must_be_like %{(LOCATE('test', "users"."name") + LOCATE('test', "users"."name"))}
-        compile(c.locate('test')+1+c.locate('test')-1 + 1)
+        _(compile(c.locate('test')+1+c.locate('test')-1 + 1))
           .must_be_like %{((((LOCATE('test', "users"."name") + 1) + LOCATE('test', "users"."name")) - 1) + 1)}
       end
 
       it "should be possible to add and substract on some nodes" do
         c = @table[:name]
-        compile(c.when(0,0).else(42) + 42).must_be_like %{(CASE "users"."name" WHEN 0 THEN 0 ELSE 42 END + 42)}
-        compile(c.when(0,0).else(42) - 42).must_be_like %{(CASE "users"."name" WHEN 0 THEN 0 ELSE 42 END - 42)}
-        compile(c.when(0,"0").else("42") + "42").must_be_like %{CONCAT(CASE "users"."name" WHEN 0 THEN '0' ELSE '42' END, '42')}
+        _(compile(c.when(0,0).else(42) + 42)).must_be_like %{(CASE "users"."name" WHEN 0 THEN 0 ELSE 42 END + 42)}
+        _(compile(c.when(0,0).else(42) - 42)).must_be_like %{(CASE "users"."name" WHEN 0 THEN 0 ELSE 42 END - 42)}
+        _(compile(c.when(0,"0").else("42") + "42")).must_be_like %{CONCAT(CASE "users"."name" WHEN 0 THEN '0' ELSE '42' END, '42')}
       end
 
       it "should be possible to desc and asc on functions" do
         c = @table[:name]
-        compile(c.asc)
+        _(compile(c.asc))
           .must_be_like %{"users"."name" ASC}
-        compile(c.substring(2).asc)
+        _(compile(c.substring(2).asc))
           .must_be_like %{SUBSTRING("users"."name", 2) ASC}
-        compile(c.substring(2).desc)
+        _(compile(c.substring(2).desc))
           .must_be_like %{SUBSTRING("users"."name", 2) DESC}
-        compile((c.locate('test')+1).asc)
+        _(compile((c.locate('test')+1).asc))
           .must_be_like %{(LOCATE('test', "users"."name") + 1) ASC}
       end
 
       it "should be possible to have multiple arguments on an OR or an AND node" do
         c = @table[:id]
-        compile((c == 1).and(c == 2, c == 3)).
-          must_be_like %{("users"."id" = 1) AND ("users"."id" = 2) AND ("users"."id" = 3)}
-        compile((c == 1).and([c == 2, c == 3])).
-          must_be_like %{("users"."id" = 1) AND ("users"."id" = 2) AND ("users"."id" = 3)}
-        compile((c == 1).or(c == 2, c == 3)).
-          must_be_like %{("users"."id" = 1) OR ("users"."id" = 2) OR ("users"."id" = 3)}
-        compile((c == 1).or([c == 2, c == 3])).
-          must_be_like %{("users"."id" = 1) OR ("users"."id" = 2) OR ("users"."id" = 3)}
+        _(compile((c == 1).and(c == 2, c == 3)))
+          .must_be_like %{("users"."id" = 1) AND ("users"."id" = 2) AND ("users"."id" = 3)}
+        _(compile((c == 1).and([c == 2, c == 3])))
+          .must_be_like %{("users"."id" = 1) AND ("users"."id" = 2) AND ("users"."id" = 3)}
+        _(compile((c == 1).or(c == 2, c == 3)))
+          .must_be_like %{("users"."id" = 1) OR ("users"."id" = 2) OR ("users"."id" = 3)}
+        _(compile((c == 1).or([c == 2, c == 3])))
+          .must_be_like %{("users"."id" = 1) OR ("users"."id" = 2) OR ("users"."id" = 3)}
       end
 
       puts "AREL VERSION : " + Arel::VERSION.to_s

--- a/test/with_ar/test_bulk_sqlite.rb
+++ b/test/with_ar/test_bulk_sqlite.rb
@@ -38,8 +38,9 @@ module ArelExtensions
       it "should import large set of data" do
         insert_manager = Arel::VERSION.to_i > 6 ? Arel::InsertManager.new().into(@table) : Arel::InsertManager.new(ActiveRecord::Base).into(@table)
         insert_manager.bulk_insert(@cols, @data)
-        sql = insert_manager.to_sql
-        sql.must_be_like %Q[INSERT INTO "users" ("id", "name", "comments", "created_at") SELECT 23 AS 'id', 'nom1' AS 'name', 'sdfdsfdsfsdf' AS 'comments', '2016-01-01' AS 'created_at' UNION ALL SELECT 25, 'nom2', 'sdfdsfdsfsdf', '2016-01-01']
+        _(insert_manager.to_sql)
+          .must_be_like %Q[INSERT INTO "users" ("id", "name", "comments", "created_at")
+                         SELECT 23 AS 'id', 'nom1' AS 'name', 'sdfdsfdsfsdf' AS 'comments', '2016-01-01' AS 'created_at' UNION ALL SELECT 25, 'nom2', 'sdfdsfdsfsdf', '2016-01-01']
       end
 
     end


### PR DESCRIPTION
Avoid these warnings:
```
DEPRECATED: global use of must_equal from /Users/akim/src/faveod/arel-extensions/test/helper.rb:16. Use _(obj).must_equal instead. This will fail in Minitest 6.
```

I'm not sure I caught all the places that needed to be updated, but there should be less warnings.

I'd like to see the result of the CI.  And then will provide more commits.