### PR TITLE
concat: accept ActiveSupport::Multibyte::Chars

### DIFF
--- a/lib/arel_extensions/nodes/function.rb
+++ b/lib/arel_extensions/nodes/function.rb
@@ -63,7 +63,7 @@ module ArelExtensions
           Arel::Nodes.build_quoted(object, self)
         when Time
           Arel::Nodes.build_quoted(object.strftime('%H:%M:%S'), self)
-        when String, Symbol
+        when ActiveSupport::Multibyte::Chars, String, Symbol
           Arel::Nodes.build_quoted(object.to_s)
         when Date
           Arel::Nodes.build_quoted(object.to_s, self)
@@ -74,7 +74,7 @@ module ArelExtensions
         when Array
           Arel::Nodes::Grouping.new(object.map{|r| convert_to_node(e)})
         else
-          raise(ArgumentError, "#{object.class} can not be converted to CONCAT arg")
+          raise(ArgumentError, "#{object.class} cannot be converted to CONCAT arg")
         end
       end
 
@@ -97,8 +97,8 @@ module ArelExtensions
           Arel::Nodes.build_quoted(object, self)
         when Time
           Arel::Nodes.build_quoted(object.strftime('%H:%M:%S'), self)
-        when String
-          Arel::Nodes.build_quoted(object)
+        when ActiveSupport::Multibyte::Chars, String
+          Arel::Nodes.build_quoted(object.to_s)
         when Date
           Arel::Nodes.build_quoted(object, self)
         when NilClass
@@ -106,7 +106,7 @@ module ArelExtensions
         when ActiveSupport::Duration
           Arel::Nodes.build_quoted(object.to_i.to_s)
         else
-          raise(ArgumentError, "#{object.class} can not be converted to CONCAT arg")
+          raise(ArgumentError, "#{object.class} cannot be converted to CONCAT arg")
         end
       end
 
@@ -116,12 +116,12 @@ module ArelExtensions
           object
         when DateTime, Time
           Arel::Nodes.build_quoted(Date.new(object.year, object.month, object.day), self)
-        when String
-          Arel::Nodes.build_quoted(Date.parse(object), self)
+        when ActiveSupport::Multibyte::Chars, String
+          Arel::Nodes.build_quoted(Date.parse(object.to_s), self)
         when Date
           Arel::Nodes.build_quoted(object, self)
         else
-          raise(ArgumentError, "#{object.class} can not be converted to Date")
+          raise(ArgumentError, "#{object.class} cannot be converted to Date")
         end
       end
 
@@ -131,12 +131,12 @@ module ArelExtensions
           object
         when DateTime, Time
           Arel::Nodes.build_quoted(object, self)
-        when String
-          Arel::Nodes.build_quoted(Time.parse(object), self)
+        when ActiveSupport::Multibyte::Chars, String
+          Arel::Nodes.build_quoted(Time.parse(object.to_s), self)
         when Date
           Arel::Nodes.build_quoted(Time.utc(object.year, object.month, object.day, 0, 0, 0), self)
         else
-          raise(ArgumentError, "#{object.class} can not be converted to Datetime")
+          raise(ArgumentError, "#{object.class} cannot be converted to Datetime")
         end
       end
 
@@ -154,7 +154,7 @@ module ArelExtensions
         when NilClass
           0
         else
-          raise(ArgumentError, "#{object.class} can not be converted to NUMBER arg")
+          raise(ArgumentError, "#{object.class} cannot be converted to NUMBER arg")
         end
       end
 


### PR DESCRIPTION
Currently if we try to pass the result of `"fôobâr".mb_chars` to concat, it ends with
```
ActiveSupport::Multibyte::Chars can not be converted to CONCAT arg
.../gems/2.5.0/gems/arel_extensions-1.2.12/lib/arel_extensions/nodes/function.rb:77:in `convert_to_node'
```