### PR TITLE
case: fix inheritance for Arel versions >= 10

### DIFF
--- a/lib/arel_extensions.rb
+++ b/lib/arel_extensions.rb
@@ -36,7 +36,7 @@ class Arel::Nodes::Function
   include Arel::Expressions
 end
 
-if Arel::VERSION >= "7.1.0"
+if Gem::Version.new(Arel::VERSION) >= Gem::Version.new("7.1.0")
   class Arel::Nodes::Case
     include Arel::Math
     include Arel::Expressions

--- a/lib/arel_extensions/nodes/case.rb
+++ b/lib/arel_extensions/nodes/case.rb
@@ -1,6 +1,6 @@
 module ArelExtensions
   module Nodes
-    if Arel::VERSION < "7.1.0"
+    if Gem::Version.new(Arel::VERSION) < Gem::Version.new("7.1.0")
       class Case < Arel::Nodes::Node
         attr_accessor :case, :conditions, :default
 

--- a/test/with_ar/all_agnostic_test.rb
+++ b/test/with_ar/all_agnostic_test.rb
@@ -581,6 +581,7 @@ module ArelExtensions
       # Case clause
       def test_case
         assert_equal 4, User.find_by_sql(@ut.project(@score.when(20.16).then(1).else(0).as('score_bin')).to_sql).sum(&:score_bin)
+        assert_equal 4, User.where(@score.when(20.16).then(1).else(0).eq(1)).count
         assert_equal 2, t(@arthur, @score.when(65.62,1).else(0)+1)
         assert_equal 0, t(@arthur, @score.when(65.62,1).else(0)-1)
         assert_equal "11", t(@arthur, @score.when(65.62).then("1").else("0")+"1")


### PR DESCRIPTION
The version comparison was being done on a string, and lexical sorting if 7 is after 1,
thus resulting in not inheriting from Arel::Nodes::Case, and then we get
errors like:

    NoMethodError: undefined method `eq' for #<ArelExtensions::Nodes::Case:0x00005578f1ac1a10>

Fix that by using the Gem::Version class.

Fixes #28