### PR TITLE
Override all methods of Arel::Nodes::Or

### DIFF
--- a/lib/arel_extensions/boolean_functions.rb
+++ b/lib/arel_extensions/boolean_functions.rb
@@ -63,8 +63,28 @@ class Arel::Nodes::Or
     @children = children
   end
 
+  def initialize_copy(other)
+    super
+    @children = other.children.copy if other.children
+  end
+
+
+  def left
+    children.first
+  end
+
+  def right
+    children[1]
+  end
+
   def hash
     children.hash
   end
+
+  def eql?(other)
+    self.class == other.class &&
+      children == other.children
+  end
+  alias :== :eql?
 
 end


### PR DESCRIPTION
This unbreaks equality checking, and possibly other things that assumed left or right contained anything.

Should fix #30 