### PR TITLE
concat: accept ActiveSupport::Multibyte::Chars

### DIFF
--- a/lib/arel_extensions/common_sql_functions.rb
+++ b/lib/arel_extensions/common_sql_functions.rb
@@ -12,7 +12,7 @@ module ArelExtensions
           db.enable_load_extension(0)
         rescue => e
           $load_extension_disabled = true
-          puts "can not load extensions #{e.inspect}"
+          puts "cannot load extensions #{e.inspect}"
         end
       end
     end
@@ -44,7 +44,7 @@ module ArelExtensions
         begin
           add_sqlite_functions
         rescue => e
-          puts "can not add sqlite functions #{e.inspect}"
+          puts "cannot add sqlite functions #{e.inspect}"
         end
       end
       if File.exist?("init/#{env_db}.sql")

--- a/lib/arel_extensions/nodes/date_diff.rb
+++ b/lib/arel_extensions/nodes/date_diff.rb
@@ -157,11 +157,11 @@ module ArelExtensions
         when Integer
           object.days
         when DateTime, Time, Date
-          raise(ArgumentError, "#{object.class} can not be converted to Integer")
+          raise(ArgumentError, "#{object.class} cannot be converted to Integer")
         when String
           Arel::Nodes.build_quoted(object)
         else
-          raise(ArgumentError, "#{object.class} can not be converted to Integer")
+          raise(ArgumentError, "#{object.class} cannot be converted to Integer")
         end
       end
     end
@@ -183,7 +183,7 @@ module ArelExtensions
           if defined?(ActiveSupport::Duration) && ActiveSupport::Duration === object
             object.to_i
           else
-            raise(ArgumentError, "#{object.class} can not be converted to Number")
+            raise(ArgumentError, "#{object.class} cannot be converted to Number")
           end
         end
       end

--- a/lib/arel_extensions/nodes/function.rb
+++ b/lib/arel_extensions/nodes/function.rb
@@ -74,7 +74,7 @@ module ArelExtensions
         when Array
           Arel::Nodes::Grouping.new(object.map{|r| convert_to_node(e)})
         else
-          raise(ArgumentError, "#{object.class} can not be converted to CONCAT arg")
+          raise(ArgumentError, "#{object.class} cannot be converted to CONCAT arg")
         end
       end
 
@@ -106,7 +106,7 @@ module ArelExtensions
         when ActiveSupport::Duration
           Arel::Nodes.build_quoted(object.to_i.to_s)
         else
-          raise(ArgumentError, "#{object.class} can not be converted to CONCAT arg")
+          raise(ArgumentError, "#{object.class} cannot be converted to CONCAT arg")
         end
       end
 
@@ -121,7 +121,7 @@ module ArelExtensions
         when Date
           Arel::Nodes.build_quoted(object, self)
         else
-          raise(ArgumentError, "#{object.class} can not be converted to Date")
+          raise(ArgumentError, "#{object.class} cannot be converted to Date")
         end
       end
 
@@ -136,7 +136,7 @@ module ArelExtensions
         when Date
           Arel::Nodes.build_quoted(Time.utc(object.year, object.month, object.day, 0, 0, 0), self)
         else
-          raise(ArgumentError, "#{object.class} can not be converted to Datetime")
+          raise(ArgumentError, "#{object.class} cannot be converted to Datetime")
         end
       end
 
@@ -154,7 +154,7 @@ module ArelExtensions
         when NilClass
           0
         else
-          raise(ArgumentError, "#{object.class} can not be converted to NUMBER arg")
+          raise(ArgumentError, "#{object.class} cannot be converted to NUMBER arg")
         end
       end
 

--- a/lib/arel_extensions/nodes/function.rb
+++ b/lib/arel_extensions/nodes/function.rb
@@ -10,6 +10,10 @@ module ArelExtensions
 
       RETURN_TYPE = :string # by default...
 
+      # Support multibyte string if they are available.
+      MBSTRING =
+        defined?(ActiveSupport::Multibyte::Chars) ? ActiveSupport::Multibyte::Chars : String
+
       # overrides as to make new Node like AliasPredication
 
       def return_type
@@ -63,7 +67,7 @@ module ArelExtensions
           Arel::Nodes.build_quoted(object, self)
         when Time
           Arel::Nodes.build_quoted(object.strftime('%H:%M:%S'), self)
-        when String, Symbol
+        when MBSTRING, String, Symbol
           Arel::Nodes.build_quoted(object.to_s)
         when Date
           Arel::Nodes.build_quoted(object.to_s, self)
@@ -97,8 +101,8 @@ module ArelExtensions
           Arel::Nodes.build_quoted(object, self)
         when Time
           Arel::Nodes.build_quoted(object.strftime('%H:%M:%S'), self)
-        when String
-          Arel::Nodes.build_quoted(object)
+        when MBSTRING, String
+          Arel::Nodes.build_quoted(object.to_s)
         when Date
           Arel::Nodes.build_quoted(object, self)
         when NilClass
@@ -116,8 +120,8 @@ module ArelExtensions
           object
         when DateTime, Time
           Arel::Nodes.build_quoted(Date.new(object.year, object.month, object.day), self)
-        when String
-          Arel::Nodes.build_quoted(Date.parse(object), self)
+        when MBSTRING, String
+          Arel::Nodes.build_quoted(Date.parse(object.to_s), self)
         when Date
           Arel::Nodes.build_quoted(object, self)
         else
@@ -131,8 +135,8 @@ module ArelExtensions
           object
         when DateTime, Time
           Arel::Nodes.build_quoted(object, self)
-        when String
-          Arel::Nodes.build_quoted(Time.parse(object), self)
+        when MBSTRING, String
+          Arel::Nodes.build_quoted(Time.parse(object.to_s), self)
         when Date
           Arel::Nodes.build_quoted(Time.utc(object.year, object.month, object.day, 0, 0, 0), self)
         else

--- a/lib/arel_extensions/predications.rb
+++ b/lib/arel_extensions/predications.rb
@@ -94,7 +94,7 @@ module ArelExtensions
       when ActiveSupport::Duration
         object.to_i
       else
-        raise(ArgumentError, "#{object.class} can not be converted to CONCAT arg")
+        raise(ArgumentError, "#{object.class} cannot be converted to CONCAT arg")
       end
     end
   end

--- a/test/real_db_test.rb
+++ b/test/real_db_test.rb
@@ -21,7 +21,7 @@ def setup_db
         db.enable_load_extension(0)
       rescue => e
         $load_extension_disabled = true
-        $stderr << "can not load extensions #{e.inspect}\n"
+        $stderr << "cannot load extensions #{e.inspect}\n"
       end
     end
     #function find_in_set


### PR DESCRIPTION
This is a revival of https://github.com/Faveod/arel-extensions/pull/27.

Currently if we try to pass the result of `val.mb_chars` to concat, it ends with
    
    ActiveSupport::Multibyte::Chars can not be converted to CONCAT arg
    .../gems/2.5.0/gems/arel_extensions-1.2.12/lib/arel_extensions/nodes/function.rb:77:in `convert_to_node'
