### PR TITLE
format: transform `%R` into `%H:%M`

### DIFF
--- a/lib/arel_extensions/nodes/format.rb
+++ b/lib/arel_extensions/nodes/format.rb
@@ -1,3 +1,5 @@
+require 'strscan'
+
 module ArelExtensions
   module Nodes
     class Format < Function
@@ -6,9 +8,32 @@ module ArelExtensions
       attr_accessor :col_type, :iso_format
       def initialize expr
         col = expr.first
-        @iso_format = expr[1]
+        @iso_format = convert_format(expr[1])
         @col_type = type_of_attribute(col)
         super [col, convert_to_string_node(@iso_format)]
+      end
+
+      private
+
+      # Address portability issues with some of the formats.
+      def convert_format(fmt)
+        s = StringScanner.new fmt
+        res = StringIO.new
+        while !s.eos?
+          res <<
+            case
+            when s.scan(/%D/)    then '%m/%d/%y'
+            when s.scan(/%F/)    then '%Y-%m-%d'
+            when s.scan(/%R/)    then '%H:%M'
+            when s.scan(/%r/)    then '%I:%M:%S %p'
+            when s.scan(/%T/)    then '%H:%M:%S'
+            when s.scan(/%v/)    then '%e-%b-%Y'
+
+            when s.scan(/[^%]+/) then s.matched
+            when s.scan(/./)     then s.matched
+            end
+        end
+        res.string
       end
     end
   end

--- a/test/with_ar/all_agnostic_test.rb
+++ b/test/with_ar/all_agnostic_test.rb
@@ -356,6 +356,7 @@ module ArelExtensions
         assert_equal '2016-05-23', t(@lucas, @created_at.format('%Y-%m-%d'))
         skip "SQL Server does not accept any format" if @env_db == 'mssql'
         assert_equal '2014/03/03 12:42:00', t(@lucas, @updated_at.format('%Y/%m/%d %H:%M:%S'))
+        assert_equal '12:42%%', t(@lucas, @updated_at.format('%R%%'))
       end
 
       def test_coalesce


### PR DESCRIPTION
This gives us more portability of the possible ISO specifiers.  Based on "man strftime".

I could not run the test suite locally, let's wait for the result!