### PR TITLE
pg: `format('%%'` should give` %`, not `%%`

### DIFF
--- a/test/with_ar/all_agnostic_test.rb
+++ b/test/with_ar/all_agnostic_test.rb
@@ -356,7 +356,6 @@ module ArelExtensions
         assert_equal '2016-05-23', t(@lucas, @created_at.format('%Y-%m-%d'))
         skip "SQL Server does not accept any format" if @env_db == 'mssql'
         assert_equal '2014/03/03 12:42:00', t(@lucas, @updated_at.format('%Y/%m/%d %H:%M:%S'))
-        skip "PG does not escape % with a double %" if @env_db == 'postgresql'
         assert_equal '12:42%', t(@lucas, @updated_at.format('%R%%'))
       end
 


### PR DESCRIPTION
* lib/arel_extensions/visitors/postgresql.rb: Formatting changes.
(Arel::Visitors::PostgreSQL::DATE_FORMAT_DIRECTIVES): Add %%.
(visit_ArelExtensions_Nodes_Format): Don't use gsub in some random
order: scan the string from left to right.

* test/with_ar/all_agnostic_test.rb: Run this test.