### PR TITLE
Improvements for strftime

### DIFF
--- a/lib/arel_extensions/visitors.rb
+++ b/lib/arel_extensions/visitors.rb
@@ -1,3 +1,4 @@
+require 'arel_extensions/visitors/convert_format'
 require 'arel_extensions/visitors/to_sql'
 require 'arel_extensions/visitors/mysql'
 require 'arel_extensions/visitors/oracle'

--- a/lib/arel_extensions/visitors/convert_format.rb
+++ b/lib/arel_extensions/visitors/convert_format.rb
@@ -1,6 +1,5 @@
 module ArelExtensions
   module Visitors
-
     # Convert date format in strftime syntax to whatever the RDBMs
     # wants, based on the table of conversion +mapping+.
     def self.strftime_to_format format, mapping

--- a/lib/arel_extensions/visitors/convert_format.rb
+++ b/lib/arel_extensions/visitors/convert_format.rb
@@ -1,0 +1,38 @@
+module ArelExtensions
+  module Visitors
+
+    # Convert date format in strftime syntax to whatever the RDBMs
+    # wants, based on the table of conversion +mapping+.
+    def self.strftime_to_format format, mapping
+      @mapping_regexps ||= {}
+      @mapping_regexps[mapping] ||=
+        Regexp.new(
+          mapping
+            .keys
+            .map{|k| Regexp.escape(k)}
+            .join('|')
+        )
+
+      regexp = @mapping_regexps[mapping]
+      s = StringScanner.new format
+      res = StringIO.new
+      while !s.eos?
+        res <<
+          case
+          when s.scan(regexp)
+            if v = mapping[s.matched]
+              v
+            else
+              # Should never happen.
+              s.matched
+            end
+          when s.scan(/[^%]+/)
+            s.matched
+          when s.scan(/./)
+            s.matched
+          end
+      end
+      res.string
+    end
+  end
+end

--- a/lib/arel_extensions/visitors/mssql.rb
+++ b/lib/arel_extensions/visitors/mssql.rb
@@ -90,12 +90,12 @@ module ArelExtensions
 
 
       def visit_ArelExtensions_Nodes_DateDiff o, collector
-        if o.right_node_type == :ruby_date || o.right_node_type == :ruby_time || o.right_node_type == :date || o.right_node_type == :datetime || o.right_node_type == :time
-          collector << if o.left_node_type == :ruby_time || o.left_node_type == :datetime || o.left_node_type == :time
-                          'DATEDIFF(second'
-                      else
-                        'DATEDIFF(day'
-                      end
+        case o.right_node_type
+        when :ruby_date, :ruby_time, :date, :datetime, :time
+          collector << case o.left_node_type
+                       when :ruby_time, :datetime, :time then 'DATEDIFF(second'
+                       else                                   'DATEDIFF(day'
+                       end
           collector << Arel::Visitors::MSSQL::COMMA
           collector = visit o.right, collector
           collector << Arel::Visitors::MSSQL::COMMA

--- a/lib/arel_extensions/visitors/mssql.rb
+++ b/lib/arel_extensions/visitors/mssql.rb
@@ -1,13 +1,17 @@
 module ArelExtensions
   module Visitors
     module MSSQL
-      Arel::Visitors::MSSQL::DATE_MAPPING = {'d' => 'day', 'm' => 'month', 'y' => 'year', 'wd' => 'weekday', 'w' => 'week', 'h' => 'hour', 'mn' => 'minute', 's' => 'second'}
+      Arel::Visitors::MSSQL::DATE_MAPPING = {
+        'd' => 'day', 'm' => 'month', 'y' => 'year', 'wd' => 'weekday', 'w' => 'week', 'h' => 'hour', 'mn' => 'minute', 's' => 'second'
+      }.freeze
+
       Arel::Visitors::MSSQL::DATE_FORMAT_DIRECTIVES = {
         '%Y' => 'YYYY', '%C' => '', '%y' => 'YY', '%m' => 'MM', '%B' =>   '', '%b' => '', '%^b' => '', # year, month
         '%d' => 'DD', '%e' => '', '%j' =>   '', '%w' => 'dw', '%A' => '', # day, weekday
         '%H' => 'hh', '%k' => '', '%I' =>   '', '%l' =>   '', '%P' => '', '%p' => '', # hours
         '%M' => 'mi', '%S' => 'ss', '%L' => 'ms', '%N' => 'ns', '%z' => 'tz'
-      }
+      }.freeze
+
       # TODO; all others... http://www.sql-server-helper.com/tips/date-formats.aspx
       Arel::Visitors::MSSQL::DATE_CONVERT_FORMATS = {
         'YYYY-MM-DD' => 120,
@@ -19,7 +23,7 @@ module ArelExtensions
         'DD-MM-YY'   => 5,
         'DD.MM.YYYY' => 104,
         'YYYY-MM-DDTHH:MM:SS:MMM' => 126
-      }
+      }.freeze
 
       # Math Functions
       def visit_ArelExtensions_Nodes_Ceil o, collector

--- a/lib/arel_extensions/visitors/mysql.rb
+++ b/lib/arel_extensions/visitors/mysql.rb
@@ -5,14 +5,14 @@ module ArelExtensions
       DATE_MAPPING = {
         'd' => 'DAY', 'm' => 'MONTH', 'w' => 'WEEK', 'y' => 'YEAR', 'wd' => 'WEEKDAY',
         'h' => 'HOUR', 'mn' => 'MINUTE', 's' => 'SECOND'
-      }
+      }.freeze
 
       DATE_FORMAT_DIRECTIVES = { # ISO C / POSIX
         '%Y' => '%Y', '%C' =>   '', '%y' => '%y', '%m' => '%m', '%B' => '%M', '%b' => '%b', '%^b' => '%b',  # year, month
         '%d' => '%d', '%e' => '%e', '%j' => '%j', '%w' => '%w', '%A' => '%W',                               # day, weekday
         '%H' => '%H', '%k' => '%k', '%I' => '%I', '%l' => '%l', '%P' => '%p', '%p' => '%p',                 # hours
         '%M' => '%i', '%S' => '%S', '%L' =>   '', '%N' => '%f', '%z' => ''
-      }
+      }.freeze
 
 
       #Math functions
@@ -207,13 +207,12 @@ module ArelExtensions
 
       def visit_ArelExtensions_Nodes_Format o, collector
         case o.col_type
-        when :date, :datetime
+        when :date, :datetime, :time
+          fmt = ArelExtensions::Visitors::strftime_to_format(o.iso_format, DATE_FORMAT_DIRECTIVES)
           collector << "DATE_FORMAT("
           collector = visit o.left, collector
           collector << COMMA
-          f = o.iso_format.dup
-          DATE_FORMAT_DIRECTIVES.each { |d, r| f.gsub!(d, r) }
-          collector = visit Arel::Nodes.build_quoted(f), collector
+          collector = visit Arel::Nodes.build_quoted(fmt), collector
           collector << ")"
         when :integer, :float, :decimal
           collector << "FORMAT("

--- a/lib/arel_extensions/visitors/oracle.rb
+++ b/lib/arel_extensions/visitors/oracle.rb
@@ -447,14 +447,11 @@ module ArelExtensions
       end
 
       def visit_ArelExtensions_Nodes_Format o, collector
+        fmt = ArelExtensions::Visitors::strftime_to_format(o.iso_format, DATE_FORMAT_DIRECTIVES)
         collector << "TO_CHAR("
         collector = visit o.left, collector
         collector << COMMA
-
-        f = o.iso_format.gsub(/\ (\w+)/, ' "\1"')
-        DATE_FORMAT_DIRECTIVES.each { |d, r| f.gsub!(d, r) }
-        collector = visit Arel::Nodes.build_quoted(f), collector
-
+        collector = visit Arel::Nodes.build_quoted(fmt), collector
         collector << ")"
         collector
       end

--- a/lib/arel_extensions/visitors/oracle12.rb
+++ b/lib/arel_extensions/visitors/oracle12.rb
@@ -84,7 +84,7 @@ module ArelExtensions
             collector << 'FORMAT JSON'
           end
           collector << ')'
-        when String,Numeric,TrueClass,FalseClass
+        when String, Numeric, TrueClass, FalseClass
           collector = visit Arel::Nodes.build_quoted("#{o.dict}"), collector
           collector << ' FORMAT JSON'
         when NilClass

--- a/lib/arel_extensions/visitors/sqlite.rb
+++ b/lib/arel_extensions/visitors/sqlite.rb
@@ -1,14 +1,21 @@
 module ArelExtensions
   module Visitors
     class Arel::Visitors::SQLite
-      DATE_MAPPING = {'d' => '%d', 'm' => '%m', 'w' => '%W', 'y' => '%Y', 'wd' => '%w', 'M' => '%M', 'h' => '%H', 'mn' => '%M', 's' => '%S'}
+      DATE_MAPPING = {
+        'd' => '%d', 'm' => '%m', 'w' => '%W', 'y' => '%Y', 'wd' => '%w', 'M' => '%M',
+        'h' => '%H', 'mn' => '%M', 's' => '%S'
+      }.freeze
+
       DATE_FORMAT_DIRECTIVES = { # ISO C / POSIX
         '%Y' => '%Y', '%C' =>   '', '%y' => '%y', '%m' => '%m', '%B' => '%M', '%b' => '%b', '%^b' => '%b', # year, month
         '%d' => '%d', '%e' => '%e', '%j' => '%j', '%w' => '%w', '%A' => '%W', # day, weekday
         '%H' => '%H', '%k' => '%k', '%I' => '%I', '%l' => '%l', '%P' => '%p', '%p' => '%p', # hours
         '%M' => '%M', '%S' => '%S', '%L' =>   '', '%N' => '%f', '%z' => '' # seconds, subseconds
-      }
-      NUMBER_COMMA_MAPPING = { 'fr_FR' => {',' => ' ','.' =>','} }
+      }.freeze
+
+      NUMBER_COMMA_MAPPING = {
+        'fr_FR' => {',' => ' ', '.' =>','}
+      }.freeze
 
       #String functions
       def visit_ArelExtensions_Nodes_IMatches o, collector # insensitive on ASCII
@@ -97,7 +104,8 @@ module ArelExtensions
       end
 
       def visit_ArelExtensions_Nodes_DateDiff o, collector
-        if o.left_node_type == :ruby_time || o.left_node_type == :datetime || o.left_node_type == :time
+        case o.left_node_type
+        when :ruby_time, :datetime, :time
           collector << "strftime('%s', "
           collector = visit o.left, collector
           collector << ") - strftime('%s', "


### PR DESCRIPTION
I believe there are several issues to fix in the handling of strftime/format.  There's also a number of things I don't understand well.  For instance mssql is not dealt with the same way as the other RDBMS:

```ruby
module ArelExtensions
  module Visitors
    module MSSQL
```

instead of

```ruby
module ArelExtensions
  module Visitors
    class Arel::Visitors::PostgreSQL
```

Why this difference?  I believe it's a mistake, introduced in cf49f1124dc76662fd7d0d143a0a7f997f9c41d9.

Anyway, I don't understand the meaning of

```ruby
module ArelExtensions
  module Visitors
    class Arel::Visitors::PostgreSQL
```

Is there a difference with just

```ruby
class Arel::Visitors::PostgreSQL
```

?

The test suite is running here: https://travis-ci.org/github/Faveod/arel-extensions/builds/743934528