### PR TITLE
Various CI build fix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -71,7 +71,7 @@ jobs:
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):
     # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@21351ecc0a7c196081abca5dc55b08f085efe09a
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
     - name: Setup gemspec

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - 3.0.0-preview1
+          - 3.0
           - 2.7
           - 2.5
           - 2.3

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -48,6 +48,7 @@ jobs:
     strategy:
       matrix:
         ruby-version:
+          - 3.1
           - 3.0
           - 2.7
           - 2.5

--- a/arel_extensions.gemspec
+++ b/arel_extensions.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |s|
   s.add_dependency('arel', '>= 6.0')
 
   s.add_development_dependency('minitest', '~> 5.9')
-  s.add_development_dependency('rdoc', '>= 6.3.1')
+  s.add_development_dependency('rdoc', '~> 6.1.0')
   s.add_development_dependency('rake', '~> 12.3.3')
 end

--- a/gemfiles/rails5_2.gemfile
+++ b/gemfiles/rails5_2.gemfile
@@ -4,6 +4,7 @@ gem 'rails', '~> 5.2.0'
 gem 'arel', '~> 9'
 
 group :development, :test do
+  gem 'bigdecimal', '1.3.5'
   gem 'activesupport', '~> 5.2.0'
   gem 'activemodel', '~> 5.2.0'
   gem 'activerecord', '~> 5.2.0'


### PR DESCRIPTION
These fixes have some certain things and some questionable things.

The questionable thing is:

1. Moving `bigdecimal` explicitly to `1.3.5`. Take a look at [their docs](https://github.com/ruby/bigdecimal#which-version-should-you-select).
2. Moving `rdoc` to `6.1.0`. This is necessary to make `ruby-2.5` + `rails 5.2` work.

Anyway, it looks like `rails 5.2` is really screwing the CI.