### PR TITLE
Json fixes

### DIFF
--- a/lib/arel_extensions/visitors/to_sql.rb
+++ b/lib/arel_extensions/visitors/to_sql.rb
@@ -8,8 +8,13 @@ module ArelExtensions
       def make_json_string expr
         Arel::Nodes.build_quoted('"') \
         + expr
+            .coalesce('')
             .replace('\\','\\\\').replace('"','\"').replace("\n", '\n') \
         + '"'
+      end
+
+      def make_json_null
+        Arel::Nodes.build_quoted("null")
       end
 
       # Math Functions
@@ -601,20 +606,20 @@ module ArelExtensions
       def json_value(o,v)
         case o.type_of_node(v)
         when :string
-          Arel.when(v.is_null).then(Arel.null).else(make_json_string(v))
+          Arel.when(v.is_null).then(make_json_null).else(make_json_string(v))
         when :date
           s = v.format('%Y-%m-%d')
-          Arel.when(s.is_null).then(Arel.null).else(make_json_string(s))
+          Arel.when(s.is_null).then(make_json_null).else(make_json_string(s))
         when :datetime
           s = v.format('%Y-%m-%dT%H:%M:%S')
-          Arel.when(s.is_null).then(Arel.null).else(make_json_string(s))
+          Arel.when(s.is_null).then(make_json_null).else(make_json_string(s))
         when :time
           s = v.format('%H:%M:%S')
-          Arel.when(s.is_null).then(Arel.null).else(make_json_string(s))
+          Arel.when(s.is_null).then(make_json_null).else(make_json_string(s))
         when :nil
-          Arel.null
+          make_json_null
         else
-          ArelExtensions::Nodes::Cast.new([v, :string]).coalesce(Arel.null)
+          ArelExtensions::Nodes::Cast.new([v, :string]).coalesce(make_json_null)
         end
       end
 
@@ -636,7 +641,7 @@ module ArelExtensions
             if i != 0
               res += ', '
             end
-            res += make_json_string(ArelExtensions::Nodes::Cast.new([k, :string]).coalesce("")) + ': '
+            res += make_json_string(ArelExtensions::Nodes::Cast.new([k, :string])) + ': '
             res += json_value(o,v)
           end
           res += '}'
@@ -658,7 +663,7 @@ module ArelExtensions
             if i != 0
               res = res + ', '
             end
-            kv = make_json_string(ArelExtensions::Nodes::Cast.new([k, :string]).coalesce("")) + ': '
+            kv = make_json_string(ArelExtensions::Nodes::Cast.new([k, :string])) + ': '
             kv += json_value(o,v)
             res = res + kv.group_concat(', ', order: Array(orders)).coalesce('')
           end


### PR DESCRIPTION
I have failed to reenable the JSON test.  The very first test fails as soon as you activate it.

However, these fixes have been used with success to fix genuine problems.  We should merge and release.

```
commit e95fcaf02a59d1251239b1410bafad1e60ff0cc4
Author: Akim Demaille <akim.demaille@gmail.com>
Date:   Wed Jan 19 15:58:04 2022 +0100

    test: unskip json tests

diff --git a/test/with_ar/all_agnostic_test.rb b/test/with_ar/all_agnostic_test.rb
index 4a62486..ec9e039 100644
--- a/test/with_ar/all_agnostic_test.rb
+++ b/test/with_ar/all_agnostic_test.rb
@@ -777,7 +777,6 @@ module ArelExtensions
       end
 
       def test_json
-        skip "Can't be tested on travis"
         # creation
         assert_equal 'Arthur', t(@arthur,Arel.json(@name))
         assert_equal ["Arthur","Arthur"], parse_json(t(@arthur,Arel.json(@name,@name)))
```