### PR TITLE
Rails 7 testing and fixes a double quotation bug

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,13 +12,14 @@ jobs:
     strategy:
       matrix:
         ruby: [3.1, 3.0, 2.7, 2.5]
-        rails: [6_1, 6, 5_2]
+        rails: [7, 6_1, 6, 5_2]
         exclude: [
           {ruby: 3.1, rails: 6  },
           {ruby: 3.1, rails: 5_2},
           {ruby: 3.0, rails: 6  },
           {ruby: 3.0, rails: 5_2},
           {ruby: 2.7, rails: 5_2},
+          {ruby: 2.5, rails: 7 },
         ]
     steps:
       - uses: actions/checkout@v2
@@ -48,13 +49,14 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [3.1, 3.0, 2.7, 2.5]
-        rails: [6_1, 6, 5_2]
+        rails: [7, 6_1, 6, 5_2]
         exclude: [
           {ruby: 3.1, rails: 6  },
           {ruby: 3.1, rails: 5_2},
           {ruby: 3.0, rails: 6  },
           {ruby: 3.0, rails: 5_2},
           {ruby: 2.7, rails: 5_2},
+          {ruby: 2.5, rails: 7 },
         ]
     services:
       postgres:
@@ -139,13 +141,14 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [3.1, 3.0, 2.7, 2.5]
-        rails: [6_1, 6, 5_2]
+        rails: [7, 6_1, 6, 5_2]
         exclude: [
           {ruby: 3.1, rails: 6  },
           {ruby: 3.1, rails: 5_2},
           {ruby: 3.0, rails: 6  },
           {ruby: 3.0, rails: 5_2},
           {ruby: 2.7, rails: 5_2},
+          {ruby: 2.5, rails: 7 },
         ]
     steps:
       - uses: actions/checkout@v2

--- a/gemfiles/rails7.gemfile
+++ b/gemfiles/rails7.gemfile
@@ -1,0 +1,30 @@
+source "https://rubygems.org"
+
+gem 'rails', '~> 7.0.1'
+
+
+group :development, :test do
+  gem 'activesupport', '~> 7.0.1'
+  gem 'activemodel', '~> 7.0.1'
+  gem 'activerecord', '~> 7.0.1'
+
+  gem "sqlite3", '~> 1.4', platforms: [:mri, :mswin, :mingw]
+  gem "mysql2", '0.5.2', platforms: [:mri, :mswin, :mingw]
+  gem "pg",'~> 1.1', platforms: [:mri, :mingw]
+
+  #gem "tiny_tds", platforms: [:mri, :mingw]  if RUBY_PLATFORM =~ /windows/
+  #gem "activerecord-sqlserver-adapter", platforms: [:mri, :mingw]
+
+  gem 'ruby-oci8', platforms: [:mri, :mswin, :mingw] if ENV.has_key? 'ORACLE_HOME'
+  gem 'activerecord-oracle_enhanced-adapter', '~> 6.0.0' if ENV.has_key? 'ORACLE_HOME'
+
+  # for JRuby
+  gem 'activerecord-jdbc-adapter', platforms: :jruby
+  gem "jdbc-sqlite3", platforms: :jruby
+  gem "activerecord-jdbcsqlite3-adapter", platforms: :jruby
+  gem "activerecord-jdbcmysql-adapter", platforms: :jruby
+  gem "activerecord-jdbcpostgresql-adapter", platforms: :jruby
+  gem "activerecord-jdbcmssql-adapter", platforms: :jruby
+end
+
+gemspec path: "../"

--- a/lib/arel_extensions/visitors/postgresql.rb
+++ b/lib/arel_extensions/visitors/postgresql.rb
@@ -86,9 +86,15 @@ module ArelExtensions
         else
           collector = visit o.left, collector
         end
-        collector << " AS \""
+        collector << " AS "
+
+        # sometimes these values are already quoted, if they are, don't double quote it
+        quote = o.right.is_a?(Arel::Nodes::SqlLiteral) && o.right[0] != '"' && o.right[-1] != '"'
+        
+        collector << '"' if quote
         collector = visit o.right, collector
-        collector << "\""
+        collector << '"' if quote
+        
         collector
       end
 

--- a/test/real_db_test.rb
+++ b/test/real_db_test.rb
@@ -8,7 +8,11 @@ require 'arel_extensions'
 def setup_db
   ActiveRecord::Base.configurations = YAML.load_file('test/database.yml')
   ActiveRecord::Base.establish_connection(ENV['DB'].try(:to_sym) || (RUBY_PLATFORM == 'java' ? :"jdbc-sqlite" : :sqlite))
-  ActiveRecord.default_timezone = :utc
+  if ActiveRecord::VERSION::MAJOR >= 7
+    ActiveRecord.default_timezone = :utc
+  else
+    ActiveRecord::Base.default_timezone = :utc
+  end
   @cnx = ActiveRecord::Base.connection
   if ActiveRecord::Base.connection.adapter_name =~ /sqlite/i
     $sqlite = true

--- a/test/real_db_test.rb
+++ b/test/real_db_test.rb
@@ -8,7 +8,7 @@ require 'arel_extensions'
 def setup_db
   ActiveRecord::Base.configurations = YAML.load_file('test/database.yml')
   ActiveRecord::Base.establish_connection(ENV['DB'].try(:to_sym) || (RUBY_PLATFORM == 'java' ? :"jdbc-sqlite" : :sqlite))
-  ActiveRecord::Base.default_timezone = :utc
+  ActiveRecord.default_timezone = :utc
   @cnx = ActiveRecord::Base.connection
   if ActiveRecord::Base.connection.adapter_name =~ /sqlite/i
     $sqlite = true

--- a/test/with_ar/all_agnostic_test.rb
+++ b/test/with_ar/all_agnostic_test.rb
@@ -166,6 +166,12 @@ module ArelExtensions
         # Since Arel10 (Rails6.1), some unwanted behaviors on aggregated calculation were present.
         # This should works no matter which version of rails is used
         assert User.group(:score).average(:id).values.all?{|e| !e.nil?}
+
+        # Since Rails 7, a patch to calculations.rb has tirggered a double 
+        # quoting of the alias name. See https://github.com/rails/rails/commit/7e6e9091e55c3357b0162d44b6ab955ed0c718d5
+        # Before the patch that fixed this the following error would occur:
+        #   ActiveRecord::StatementInvalid: PG::SyntaxError: ERROR:  zero-length delimited identifier at or near """"
+        assert User.group(:score).count(:id).values.all?{|e| !e.nil?}
       end
 
       # String Functions

--- a/test/with_ar/all_agnostic_test.rb
+++ b/test/with_ar/all_agnostic_test.rb
@@ -14,7 +14,11 @@ module ArelExtensions
           @env_db = ENV['DB']
         end
         ActiveRecord::Base.establish_connection(@env_db.try(:to_sym) || (RUBY_PLATFORM == 'java' ? :"jdbc-sqlite" : :sqlite))
-        ActiveRecord.default_timezone = :utc
+        if ActiveRecord::VERSION::MAJOR >= 7
+          ActiveRecord.default_timezone = :utc
+        else
+          ActiveRecord::Base.default_timezone = :utc
+        end
         @cnx = ActiveRecord::Base.connection
         $sqlite = @cnx.adapter_name =~ /sqlite/i
         $load_extension_disabled ||= false

--- a/test/with_ar/all_agnostic_test.rb
+++ b/test/with_ar/all_agnostic_test.rb
@@ -14,7 +14,7 @@ module ArelExtensions
           @env_db = ENV['DB']
         end
         ActiveRecord::Base.establish_connection(@env_db.try(:to_sym) || (RUBY_PLATFORM == 'java' ? :"jdbc-sqlite" : :sqlite))
-        ActiveRecord::Base.default_timezone = :utc
+        ActiveRecord.default_timezone = :utc
         @cnx = ActiveRecord::Base.connection
         $sqlite = @cnx.adapter_name =~ /sqlite/i
         $load_extension_disabled ||= false

--- a/test/with_ar/insert_agnostic_test.rb
+++ b/test/with_ar/insert_agnostic_test.rb
@@ -13,7 +13,7 @@ module ArelExtensions
           @env_db = ENV['DB']
         end
         ActiveRecord::Base.establish_connection(@env_db.try(:to_sym) || (RUBY_PLATFORM == 'java' ? :"jdbc-sqlite" : :sqlite))
-        ActiveRecord::Base.default_timezone = :utc
+        ActiveRecord.default_timezone = :utc
         @cnx = ActiveRecord::Base.connection
         Arel::Table.engine = ActiveRecord::Base
         if File.exist?("init/#{@env_db}.sql")

--- a/test/with_ar/insert_agnostic_test.rb
+++ b/test/with_ar/insert_agnostic_test.rb
@@ -13,7 +13,11 @@ module ArelExtensions
           @env_db = ENV['DB']
         end
         ActiveRecord::Base.establish_connection(@env_db.try(:to_sym) || (RUBY_PLATFORM == 'java' ? :"jdbc-sqlite" : :sqlite))
-        ActiveRecord.default_timezone = :utc
+        if ActiveRecord::VERSION::MAJOR >= 7
+          ActiveRecord.default_timezone = :utc
+        else
+          ActiveRecord::Base.default_timezone = :utc
+        end
         @cnx = ActiveRecord::Base.connection
         Arel::Table.engine = ActiveRecord::Base
         if File.exist?("init/#{@env_db}.sql")

--- a/test/with_ar/test_bulk_sqlite.rb
+++ b/test/with_ar/test_bulk_sqlite.rb
@@ -6,7 +6,7 @@ module ArelExtensions
       before do
         ActiveRecord::Base.configurations = YAML.load_file('test/database.yml')
         ActiveRecord::Base.establish_connection(ENV['DB'] || (RUBY_PLATFORM == 'java' ? :"jdbc-sqlite" : :sqlite))
-        ActiveRecord::Base.default_timezone = :utc
+        ActiveRecord.default_timezone = :utc
         @cnx = ActiveRecord::Base.connection
         Arel::Table.engine = ActiveRecord::Base
         @cnx.drop_table(:users) rescue nil

--- a/test/with_ar/test_bulk_sqlite.rb
+++ b/test/with_ar/test_bulk_sqlite.rb
@@ -6,7 +6,11 @@ module ArelExtensions
       before do
         ActiveRecord::Base.configurations = YAML.load_file('test/database.yml')
         ActiveRecord::Base.establish_connection(ENV['DB'] || (RUBY_PLATFORM == 'java' ? :"jdbc-sqlite" : :sqlite))
-        ActiveRecord.default_timezone = :utc
+        if ActiveRecord::VERSION::MAJOR >= 7
+          ActiveRecord.default_timezone = :utc
+        else
+          ActiveRecord::Base.default_timezone = :utc
+        end
         @cnx = ActiveRecord::Base.connection
         Arel::Table.engine = ActiveRecord::Base
         @cnx.drop_table(:users) rescue nil

--- a/test/with_ar/test_math_sqlite.rb
+++ b/test/with_ar/test_math_sqlite.rb
@@ -6,7 +6,11 @@ module ArelExtensions
       before do
         ActiveRecord::Base.configurations = YAML.load_file('test/database.yml')
         ActiveRecord::Base.establish_connection(ENV['DB'] || (RUBY_PLATFORM == 'java' ? :"jdbc-sqlite" : :sqlite))
-        ActiveRecord.default_timezone = :utc
+        if ActiveRecord::VERSION::MAJOR >= 7
+          ActiveRecord.default_timezone = :utc
+        else
+          ActiveRecord::Base.default_timezone = :utc
+        end
         Arel::Table.engine = ActiveRecord::Base
         @cnx = ActiveRecord::Base.connection
         @cnx.drop_table(:users) rescue nil

--- a/test/with_ar/test_math_sqlite.rb
+++ b/test/with_ar/test_math_sqlite.rb
@@ -6,7 +6,7 @@ module ArelExtensions
       before do
         ActiveRecord::Base.configurations = YAML.load_file('test/database.yml')
         ActiveRecord::Base.establish_connection(ENV['DB'] || (RUBY_PLATFORM == 'java' ? :"jdbc-sqlite" : :sqlite))
-        ActiveRecord::Base.default_timezone = :utc
+        ActiveRecord.default_timezone = :utc
         Arel::Table.engine = ActiveRecord::Base
         @cnx = ActiveRecord::Base.connection
         @cnx.drop_table(:users) rescue nil

--- a/test/with_ar/test_string_mysql.rb
+++ b/test/with_ar/test_string_mysql.rb
@@ -7,7 +7,7 @@ module ArelExtensions
       before do
         ActiveRecord::Base.configurations = YAML.load_file('test/database.yml')
         ActiveRecord::Base.establish_connection(ENV['DB'] || (RUBY_PLATFORM == 'java' ? :"jdbc-mysql" : :mysql))
-        ActiveRecord::Base.default_timezone = :utc
+        ActiveRecord.default_timezone = :utc
         begin
           @cnx = ActiveRecord::Base.connection
         rescue => e

--- a/test/with_ar/test_string_mysql.rb
+++ b/test/with_ar/test_string_mysql.rb
@@ -7,7 +7,11 @@ module ArelExtensions
       before do
         ActiveRecord::Base.configurations = YAML.load_file('test/database.yml')
         ActiveRecord::Base.establish_connection(ENV['DB'] || (RUBY_PLATFORM == 'java' ? :"jdbc-mysql" : :mysql))
-        ActiveRecord.default_timezone = :utc
+        if ActiveRecord::VERSION::MAJOR >= 7
+          ActiveRecord.default_timezone = :utc
+        else
+          ActiveRecord::Base.default_timezone = :utc
+        end
         begin
           @cnx = ActiveRecord::Base.connection
         rescue => e

--- a/test/with_ar/test_string_sqlite.rb
+++ b/test/with_ar/test_string_sqlite.rb
@@ -7,7 +7,11 @@ module ArelExtensions
       before do
         ActiveRecord::Base.configurations = YAML.load_file('test/database.yml')
         ActiveRecord::Base.establish_connection(ENV['DB'] || (RUBY_PLATFORM == 'java' ? :"jdbc-sqlite" : :sqlite))
-        ActiveRecord.default_timezone = :utc
+        if ActiveRecord::VERSION::MAJOR >= 7
+          ActiveRecord.default_timezone = :utc
+        else
+          ActiveRecord::Base.default_timezone = :utc
+        end
         @cnx = ActiveRecord::Base.connection
         Arel::Table.engine = ActiveRecord::Base
         @cnx.drop_table(:users) rescue nil

--- a/test/with_ar/test_string_sqlite.rb
+++ b/test/with_ar/test_string_sqlite.rb
@@ -7,7 +7,7 @@ module ArelExtensions
       before do
         ActiveRecord::Base.configurations = YAML.load_file('test/database.yml')
         ActiveRecord::Base.establish_connection(ENV['DB'] || (RUBY_PLATFORM == 'java' ? :"jdbc-sqlite" : :sqlite))
-        ActiveRecord::Base.default_timezone = :utc
+        ActiveRecord.default_timezone = :utc
         @cnx = ActiveRecord::Base.connection
         Arel::Table.engine = ActiveRecord::Base
         @cnx.drop_table(:users) rescue nil


### PR DESCRIPTION
Hi!

I found a bug when I upgraded to Rails 7. I found it pretty hard to try and work out what was going on so I just fixed it.

I also had to add support files for testing Rails 7. Sorry for the multi-concerned PR but it didn't really make sense including the fix without the support files needed to verify the bug.

You can cherry pick either commit if it's an issue.

I'm not sure my fix is the best fix. Another option I thought of was stripping quotes inside the `Arel::Nodes::As` class so the current visitor could continue to always quote the column. However, I couldn't work out how to do it easily.

Someone else encountered this issue: https://github.com/rails/rails/issues/44099
Rails introduced the problem in https://github.com/rails/rails/commit/7e6e9091e55c3357b0162d44b6ab955ed0c718d5 by quoting an alias name.
Related to: https://github.com/Faveod/arel-extensions/issues/38#issuecomment-750975055
