### PR TITLE
style: s/WthAr/WithAr/

### DIFF
--- a/test/with_ar/all_agnostic_test.rb
+++ b/test/with_ar/all_agnostic_test.rb
@@ -2,7 +2,7 @@ require 'arelx_test_helper'
 require 'date'
 
 module ArelExtensions
-  module WthAr
+  module WithAr
     class ListTest < Minitest::Test
       require 'minitest/pride'
       def connect_db

--- a/test/with_ar/insert_agnostic_test.rb
+++ b/test/with_ar/insert_agnostic_test.rb
@@ -2,7 +2,7 @@ require 'arelx_test_helper'
 require 'date'
 
 module ArelExtensions
-  module WthAr
+  module WithAr
     class InsertManagerTest < Minitest::Test
       def setup_db
         ActiveRecord::Base.configurations = YAML.load_file('test/database.yml')

--- a/test/with_ar/test_bulk_sqlite.rb
+++ b/test/with_ar/test_bulk_sqlite.rb
@@ -1,7 +1,7 @@
 require 'arelx_test_helper'
 
 module ArelExtensions
-  module WthAr
+  module WithAr
     describe 'the sqlite visitor' do
       before do
         ActiveRecord::Base.configurations = YAML.load_file('test/database.yml')

--- a/test/with_ar/test_math_sqlite.rb
+++ b/test/with_ar/test_math_sqlite.rb
@@ -1,7 +1,7 @@
 require 'arelx_test_helper'
 
 module ArelExtensions
-  module WthAr
+  module WithAr
     describe 'the sqlite visitor can do maths' do
       before do
         ActiveRecord::Base.configurations = YAML.load_file('test/database.yml')

--- a/test/with_ar/test_string_mysql.rb
+++ b/test/with_ar/test_string_mysql.rb
@@ -2,7 +2,7 @@ require 'arelx_test_helper'
 require 'date'
 
 module ArelExtensions
-  module WthAr
+  module WithAr
     describe 'the mysql visitor can do string operations' do
       before do
         ActiveRecord::Base.configurations = YAML.load_file('test/database.yml')

--- a/test/with_ar/test_string_sqlite.rb
+++ b/test/with_ar/test_string_sqlite.rb
@@ -2,7 +2,7 @@ require 'arelx_test_helper'
 require 'date'
 
 module ArelExtensions
-  module WthAr
+  module WithAr
     describe 'the sqlite visitor can do string operations' do
       before do
         ActiveRecord::Base.configurations = YAML.load_file('test/database.yml')


### PR DESCRIPTION
There's really no good reason for `WthAr`, which really looks like a copy-pasted typo.