### PR TITLE
CI: Github Action re-write + windows support

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,23 +1,61 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
-# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+name: Build and Test
 
-name: Ruby
+# Ruby + Rails Compatibility Matrix from here:
+# https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
-  test:
-
+  job_build_gem:
+    name: build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: [3.1, 3.0, 2.7, 2.5]
+        rails: [6_1, 6, 5_2]
+        exclude: [
+          {ruby: 3.1, rails: 6  },
+          {ruby: 3.1, rails: 5_2},
+          {ruby: 3.0, rails: 6  },
+          {ruby: 3.0, rails: 5_2},
+          {ruby: 2.7, rails: 5_2},
+        ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Setup gemspec
+        if: ${{ matrix.rails == '6_1' || matrix.rails == '6' }}
+        run: |
+          cp ./gemspecs/arel_extensions-v2.gemspec ./arel_extensions.gemspec
+          cp ./version_v2.rb lib/arel_extensions/version.rb
+          cp ./gemfiles/rails${{ matrix.rails }}.gemfile ./Gemfile
+      - name: Build source gem
+        run: gem build arel_extensions.gemspec
+      - name: Upload source gem
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.ruby }}-${{ matrix.rails }}-gem
+          path: "*.gem"
 
+  job_test_linux:
+    name: test linux
+    needs: job_build_gem
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [3.1, 3.0, 2.7, 2.5]
+        rails: [6_1, 6, 5_2]
+        exclude: [
+          {ruby: 3.1, rails: 6  },
+          {ruby: 3.1, rails: 5_2},
+          {ruby: 3.0, rails: 6  },
+          {ruby: 3.0, rails: 5_2},
+          {ruby: 2.7, rails: 5_2},
+        ]
     services:
       postgres:
         image: postgres:11.6-alpine
@@ -44,59 +82,39 @@ jobs:
           --health-interval=10s
           --health-timeout=5s
           --health-retries=3
-
-    strategy:
-      matrix:
-        ruby-version:
-          - 3.1
-          - 3.0
-          - 2.7
-          - 2.5
-          - 2.3
-        rails-version:
-          - 6_1
-          - 6
-          - 5_2
-        exclude:
-          - ruby-version: 2.3
-            rails-version: 6_1
-          - ruby-version: 2.3
-            rails-version: 6
-          - ruby-version: 3.0.0-preview1
-            rails-version: 5.2
-    continue-on-error: ${{ true }}
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby-version }}
-    - name: Setup gemspec
-      if: ${{ matrix.rails-version == '6_1' || matrix.rails-version == '6' }}
-      run: cp ./gemspecs/arel_extensions-v2.gemspec ./arel_extensions.gemspec
-    - name: Install dependencies
-      run: |
-        export BUNDLE_GEMFILE=gemfiles/rails${{ matrix.rails-version }}.gemfile
-        bundle install
-    - name: Run test to_sql
-      run: rake test:to_sql
-    - name: Run test Postgres
-      env:
-        PGHOST: localhost
-        PGUSER: postgres
-      run: rake test:postgresql
-    - name: Run test MySql
-      env:
-        DB_CONNECTION: mysql
-        DB_HOST: 127.0.0.1
-        DB_PORT: 3306
-        DB_DATABASE: arext_test
-        DB_USERNAME: travis
-      run: |
-        mysql --host 127.0.0.1 --port 3306 -uroot -e 'create user travis;'
-        mysql --host 127.0.0.1 --port 3306 -uroot -e 'GRANT ALL PRIVILEGES ON arext_test.* TO travis;'
-        rake test:mysql
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Update system-wide gems
+        run: gem update --system
+      - name: bundle install
+        run: |
+          bundle config set gemfile ./gemfiles/rails${{ matrix.rails }}.gemfile
+          bundle install
+      - name: Download gem from build job
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ matrix.ruby }}-${{ matrix.rails }}-gem
+      - name: Install downloaded gem
+        run: gem install --local *.gem --verbose
+      - name: Run test to_sql
+        run: rake test:to_sql
+      - name: Run test Postgres
+        env:
+          PGHOST: localhost
+          PGUSER: postgres
+        run: rake test:postgresql
+      - name: Run test MySql
+        env:
+          DB_CONNECTION: mysql
+          DB_HOST: 127.0.0.1
+          DB_PORT: 3306
+          DB_DATABASE: arext_test
+          DB_USERNAME: travis
+        run: |
+          mysql --host 127.0.0.1 --port 3306 -uroot -e 'create user travis;'
+          mysql --host 127.0.0.1 --port 3306 -uroot -e 'GRANT ALL PRIVILEGES ON arext_test.* TO travis;'
+          rake test:mysql

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -88,6 +88,15 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+      - name: Install FreeTDS
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y freetds-dev
+      - name: Install MSSQL 2019
+        uses: potatoqualitee/mssqlsuite@v1
+        with:
+          install: sqlengine, sqlclient, sqlpackage, localdb
+          sa-password: Password12!
       - name: Update system-wide gems
         run: gem update --system
       - name: bundle install
@@ -118,3 +127,6 @@ jobs:
           mysql --host 127.0.0.1 --port 3306 -uroot -e 'create user travis;'
           mysql --host 127.0.0.1 --port 3306 -uroot -e 'GRANT ALL PRIVILEGES ON arext_test.* TO travis;'
           rake test:mysql
+      - name: Run test mssql
+        run: rake test:mssql
+

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -130,3 +130,51 @@ jobs:
       - name: Run test mssql
         run: rake test:mssql
 
+
+  job_test_windows:
+    name: test windows
+    needs: job_build_gem
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [3.1, 3.0, 2.7, 2.5]
+        rails: [6_1, 6, 5_2]
+        exclude: [
+          {ruby: 3.1, rails: 6  },
+          {ruby: 3.1, rails: 5_2},
+          {ruby: 3.0, rails: 6  },
+          {ruby: 3.0, rails: 5_2},
+          {ruby: 2.7, rails: 5_2},
+        ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install mssql
+        uses: potatoqualitee/mssqlsuite@v1
+        with:
+          install: sqlengine, sqlclient, sqlpackage, localdb
+          sa-password: Password12!
+      - name: Set up Ruby
+        uses: MSP-Greg/ruby-setup-ruby@win-ucrt-1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Install required packages on Windows
+        shell: cmd
+        run: |
+          ridk exec sh -c "pacman --sync --needed --noconfirm  ${MINGW_PACKAGE_PREFIX}-gcc"
+      - name: Update system-wide gems
+        run: gem update --system
+      - name: bundle install
+        run: |
+          bundle config set gemfile .\gemfiles\rails${{ matrix.rails }}.gemfile
+          bundle install --verbose
+      - name: Download gem from build job
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ matrix.ruby }}-${{ matrix.rails }}-gem
+      - name: Install downloaded gem
+        run: gem install --local *.gem --verbose
+      - name: Run test to_sql
+        run: rake test:to_sql
+      - name: Run test mssql
+        run: rake test:mssql

--- a/README.md
+++ b/README.md
@@ -596,3 +596,15 @@ User.connection.execute(insert_manager.to_sql)
   </tr>
   </tbody>
 </table>
+
+## Version Compatibility
+
+<table>
+  <tr><th>Ruby</th> <th>Rails</th>    <th>Arel Extensions</th></tr>
+  <tr><td>3.1</td>  <td>6.1</td>      <td>2</td></tr>
+  <tr><td>3.0</td>  <td>6.1</td>      <td>2</td></tr>
+  <tr><td>2.7</td>  <td>6.1, 6.0</td> <td>2</td></tr>
+  <tr><td>2.5</td>  <td>6.1, 6.0</td> <td>2</td></tr>
+  <tr><td>2.5</td>  <td>5.2</td>      <td>1</td></tr>
+</table>
+

--- a/README.md
+++ b/README.md
@@ -608,3 +608,33 @@ User.connection.execute(insert_manager.to_sql)
   <tr><td>2.5</td>  <td>5.2</td>      <td>1</td></tr>
 </table>
 
+## Development
+
+Let's say you want to develop/test for `ruby 2.7.5` and `rails 5.2`.
+
+You will need to fix your ruby version:
+
+```bash
+rbenv install 2.7.5
+rbenv local 2.7.5
+```
+
+Fix your gemfiles:
+
+```bash
+bundle config set --local gemfile ./gemfiles/rails6.gemfile
+```
+
+Install dependencies:
+```bash
+bundle install
+```
+
+Develop, then test:
+
+```bash
+bundle exec rake test:to_sql
+```
+
+Refer to the [Version Compatibility](#version-compatibility) section to correctly
+set your gemfile.

--- a/gemfiles/rails5_2.gemfile
+++ b/gemfiles/rails5_2.gemfile
@@ -9,12 +9,12 @@ group :development, :test do
   gem 'activemodel', '~> 5.2.0'
   gem 'activerecord', '~> 5.2.0'
 
-  gem "sqlite3", '<= 1.3.13', platforms: [:mri, :mswin, :mingw]
-  gem "mysql2", '0.4.10', platforms: [:mri, :mswin, :mingw]
-  gem "pg",'< 1.0.0', platforms: [:mri, :mingw]
+  gem "sqlite3", '<= 1.3.13', platforms: [:mri]
+  gem "mysql2", '0.4.10', platforms: [:mri]
+  gem "pg",'< 1.0.0', platforms: [:mri]
 
-  gem "tiny_tds", platforms: [:mri, :mingw]  if RUBY_PLATFORM =~ /windows/
-  # gem "activerecord-sqlserver-adapter", :platforms => [:mri, :mingw]
+  gem "tiny_tds", platforms: [:mri, :mingw, :x64_mingw, :mswin]
+  gem "activerecord-sqlserver-adapter", '~> 5.2',  :platforms => [:mri, :mingw, :x64_mingw, :mswin]
 
   gem 'ruby-oci8', platforms: [:mri, :mswin, :mingw] if ENV.has_key? 'ORACLE_HOME'
   gem 'activerecord-oracle_enhanced-adapter', '~> 5.2.0' if ENV.has_key? 'ORACLE_HOME'

--- a/gemfiles/rails6.gemfile
+++ b/gemfiles/rails6.gemfile
@@ -8,12 +8,12 @@ group :development, :test do
   gem 'activemodel', '~> 6.0.0'
   gem 'activerecord', '~> 6.0.0'
 
-  gem "sqlite3", '~> 1.4', platforms: [:mri, :mswin, :mingw]
-  gem "mysql2", '0.5.2', platforms: [:mri, :mswin, :mingw]
-  gem "pg",'< 1.0.0', platforms: [:mri, :mingw]
+  gem "sqlite3", '~> 1.4', platforms: [:mri]
+ gem "mysql2", '0.5.2', platforms: [:mri]
+ gem "pg",'< 1.0.0', platforms: [:mri]
 
-  #gem "tiny_tds", platforms: [:mri, :mingw]  if RUBY_PLATFORM =~ /windows/
-  #gem "activerecord-sqlserver-adapter", platforms: [:mri, :mingw]
+  gem "tiny_tds", platforms: [:mri, :mingw, :x64_mingw, :mswin]
+  gem "activerecord-sqlserver-adapter", '~> 6.0', platforms: [:mri, :mingw, :x64_mingw, :mswin]
 
   gem 'ruby-oci8', platforms: [:mri, :mswin, :mingw] if ENV.has_key? 'ORACLE_HOME'
   gem 'activerecord-oracle_enhanced-adapter', '~> 6.0.0' if ENV.has_key? 'ORACLE_HOME'

--- a/gemfiles/rails6_1.gemfile
+++ b/gemfiles/rails6_1.gemfile
@@ -8,12 +8,12 @@ group :development, :test do
   gem 'activemodel', '~> 6.1.0'
   gem 'activerecord', '~> 6.1.0'
 
-  gem "sqlite3", '~> 1.4', platforms: [:mri, :mswin, :mingw]
-  gem "mysql2", '0.5.2', platforms: [:mri, :mswin, :mingw]
-  gem "pg",'~> 1.1', platforms: [:mri, :mingw]
+  gem "sqlite3", '~> 1.4', platforms: [:mri]
+  gem "mysql2", '0.5.2', platforms: [:mri]
+  gem "pg",'~> 1.1', platforms: [:mri]
 
-  #gem "tiny_tds", platforms: [:mri, :mingw]  if RUBY_PLATFORM =~ /windows/
-  #gem "activerecord-sqlserver-adapter", platforms: [:mri, :mingw]
+  gem "tiny_tds", platforms: [:mri, :mingw, :x64_mingw, :mswin]
+  gem "activerecord-sqlserver-adapter", '~> 6.1.0', platforms: [:mri, :mingw, :x64_mingw, :mswin]
 
   gem 'ruby-oci8', platforms: [:mri, :mswin, :mingw] if ENV.has_key? 'ORACLE_HOME'
   gem 'activerecord-oracle_enhanced-adapter', '~> 6.0.0' if ENV.has_key? 'ORACLE_HOME'


### PR DESCRIPTION
This PR does the following:

1. Fix development/test dependencies for rails 6.1, 6.0, and 5.2
1. Add documentation to `README` on how to run tests locally 
1. Separate jobs into `build` and `test`
1. Add `mssql` test for linux: tested against a MS SQL Server 2019 instance
1. Add Windows support (And maybe drop AppVayor in a later instance)? Test `mssql` and the platform-agnostic `to_sql` only.