### PR TITLE
tests: jruby: remove unnecessary Arel::Table.engine intialization

### DIFF
--- a/test/arelx_test_helper.rb
+++ b/test/arelx_test_helper.rb
@@ -52,7 +52,6 @@ end
 load_lib(db_and_gem[ENV['DB']])
 
 require 'arel_extensions'
-Arel::Table.engine = FakeRecord::Base.new
 
 $arel_silence_type_casting_deprecation = true
 


### PR DESCRIPTION
This initialization was at the source of flakiness in jruby 9.2 .

There's no need for intializing with FakeRecord when every single
test decides whether to use it to do in vitro tests, or connect
directly through proper DB adapters in an integration test.