### PR TITLE
Fix column_of behavior for missing columns

### DIFF
--- a/lib/arel_extensions.rb
+++ b/lib/arel_extensions.rb
@@ -91,6 +91,10 @@ if defined?(Arel::Visitors::SQLServer)
 end
 
 module Arel
+  def self.column_of table_name, column_name
+    ArelExtensions.column_of(table_name, column_name)
+  end
+
   def self.duration s, expr
     ArelExtensions::Nodes::Duration.new("#{s}i", expr)
   end

--- a/lib/arel_extensions.rb
+++ b/lib/arel_extensions.rb
@@ -51,6 +51,7 @@ if Gem::Version.new(Arel::VERSION) >= Gem::Version.new("7.1.0")
   end
 end
 
+require 'arel_extensions/helpers'
 require 'arel_extensions/version'
 require 'arel_extensions/aliases'
 require 'arel_extensions/attributes'

--- a/lib/arel_extensions/helpers.rb
+++ b/lib/arel_extensions/helpers.rb
@@ -16,16 +16,12 @@ module ArelExtensions
   # coveing all these cases.
 
   def self.column_of_via_arel_table(table_name, column_name)
-    begin
-      Arel::Table.engine.connection.schema_cache.columns_hash(table_name)[column_name]
+    Arel::Table.engine.connection.schema_cache.columns_hash(table_name)[column_name]
     rescue NoMethodError
       nil
-    rescue Exception => e
-      puts "Failed to fetch column info for #{table_name}.#{column_name} ."
-      puts "This should never be reached."
-      puts "#{e.class}: #{e}"
+    rescue => e
+      warn("Warning: Unexpected exception caught while fetching column name for #{table_name}.#{column_name} in `column_of_via_arel_table`\n#{e.class}: #{e}")
       nil
-    end
   end
 
   def self.column_of(table_name, column_name)
@@ -44,7 +40,12 @@ module ArelExtensions
         column_of_via_arel_table(table_name, column_name)
       end
     end
-    rescue
+    rescue ActiveRecord::ConnectionNotEstablished
+      column_of_via_arel_table(table_name, column_name)
+    rescue ActiveRecord::StatementInvalid
+      nil
+    rescue => e
+      warn("Warning: Unexpected exception caught while fetching column name for #{table_name}.#{column_name} in `column_of`\n#{e.class}: #{e}")
       nil
   end
 end

--- a/lib/arel_extensions/helpers.rb
+++ b/lib/arel_extensions/helpers.rb
@@ -29,20 +29,23 @@ module ArelExtensions
   end
 
   def self.column_of(table_name, column_name)
-    use_arel_table = !ActiveRecord::Base.connected? || \
-      (ActiveRecord::Base.connection.pool.respond_to?(:schema_cache) && ActiveRecord::Base.connection.pool.schema_cache.nil?)
+    begin
+      use_arel_table = !ActiveRecord::Base.connected? || \
+        (ActiveRecord::Base.connection.pool.respond_to?(:schema_cache) && ActiveRecord::Base.connection.pool.schema_cache.nil?)
 
-    if use_arel_table
-      column_of_via_arel_table(table_name, column_name)
-    else
-      if ActiveRecord::Base.connection.pool.respond_to?(:pool_config)
-        ActiveRecord::Base.connection.pool.pool_config.schema_cache.columns_hash(table_name)[column_name]
-      elsif ActiveRecord::Base.connection.pool.respond_to?(:schema_cache)
-        ActiveRecord::Base.connection.pool.schema_cache.columns_hash(table_name)[column_name]
-      else
-        puts ">>> We really shouldn't be here #{table_name}.#{column_name}"
+      if use_arel_table
         column_of_via_arel_table(table_name, column_name)
+      else
+        if ActiveRecord::Base.connection.pool.respond_to?(:pool_config)
+          ActiveRecord::Base.connection.pool.pool_config.schema_cache.columns_hash(table_name)[column_name]
+        elsif ActiveRecord::Base.connection.pool.respond_to?(:schema_cache)
+          ActiveRecord::Base.connection.pool.schema_cache.columns_hash(table_name)[column_name]
+        else
+          column_of_via_arel_table(table_name, column_name)
+        end
       end
+    rescue
+      nil
     end
   end
 end

--- a/lib/arel_extensions/math.rb
+++ b/lib/arel_extensions/math.rb
@@ -40,7 +40,7 @@ module ArelExtensions
       when Arel::Nodes::Function
         Arel.grouping(Arel::Nodes::Addition.new self, other)
       else
-        col = self.respond_to?(:relation)? ArelExtensions::column_of(self.relation.table_name, self.name.to_s) : nil
+        col = self.respond_to?(:relation)? ArelExtensions.column_of(self.relation.table_name, self.name.to_s) : nil
         if (!col) # if the column doesn't exist in the database
           Arel.grouping(Arel::Nodes::Addition.new(self, Arel.quoted(other)))
         else
@@ -84,7 +84,7 @@ module ArelExtensions
       when Arel::Nodes::Function
         Arel.grouping(Arel::Nodes::Subtraction.new(self, Arel.quoted(other)))
       else
-        col = ArelExtensions::column_of(self.relation.table_name, self.name.to_s)
+        col = ArelExtensions.column_of(self.relation.table_name, self.name.to_s)
         if (!col) # if the column doesn't exist in the database
           Arel.grouping(Arel::Nodes::Subtraction.new(self, Arel.quoted(other)))
         else
@@ -92,7 +92,7 @@ module ArelExtensions
           if (arg == :date || arg == :datetime)
             case other
             when Arel::Attributes::Attribute
-              col2 = ArelExtensions::column_of(other.relation.table_name, other.name.to_s)
+              col2 = ArelExtensions.column_of(other.relation.table_name, other.name.to_s)
               if (!col2) # if the column doesn't exist in the database
                 ArelExtensions::Nodes::DateSub.new [self, other]
               else

--- a/lib/arel_extensions/math.rb
+++ b/lib/arel_extensions/math.rb
@@ -38,7 +38,7 @@ module ArelExtensions
       when Arel::Nodes::Function
         Arel.grouping(Arel::Nodes::Addition.new self, other)
       else
-        col = self.respond_to?(:relation)? ArelExtensions.column_of(self.relation.table_name, self.name.to_s) : nil
+        col = Arel.column_of(self.relation.table_name, self.name.to_s) if self.respond_to?(:relation)
         if (!col) # if the column doesn't exist in the database
           Arel.grouping(Arel::Nodes::Addition.new(self, Arel.quoted(other)))
         else
@@ -82,7 +82,7 @@ module ArelExtensions
       when Arel::Nodes::Function
         Arel.grouping(Arel::Nodes::Subtraction.new(self, Arel.quoted(other)))
       else
-        col = ArelExtensions.column_of(self.relation.table_name, self.name.to_s)
+        col = Arel.column_of(self.relation.table_name, self.name.to_s)
         if (!col) # if the column doesn't exist in the database
           Arel.grouping(Arel::Nodes::Subtraction.new(self, Arel.quoted(other)))
         else
@@ -90,7 +90,7 @@ module ArelExtensions
           if (arg == :date || arg == :datetime)
             case other
             when Arel::Attributes::Attribute
-              col2 = ArelExtensions.column_of(other.relation.table_name, other.name.to_s)
+              col2 = Arel.column_of(other.relation.table_name, other.name.to_s)
               if (!col2) # if the column doesn't exist in the database
                 ArelExtensions::Nodes::DateSub.new [self, other]
               else

--- a/lib/arel_extensions/math.rb
+++ b/lib/arel_extensions/math.rb
@@ -1,5 +1,3 @@
-require 'arel_extensions/helpers'
-
 require 'arel_extensions/nodes'
 require 'arel_extensions/nodes/function'
 require 'arel_extensions/nodes/concat'

--- a/lib/arel_extensions/nodes/case.rb
+++ b/lib/arel_extensions/nodes/case.rb
@@ -1,5 +1,3 @@
-require 'arel_extensions/helpers'
-
 module ArelExtensions
   module Nodes
     if Gem::Version.new(Arel::VERSION) < Gem::Version.new("7.1.0")

--- a/lib/arel_extensions/nodes/case.rb
+++ b/lib/arel_extensions/nodes/case.rb
@@ -59,7 +59,7 @@ module ArelExtensions
           when Date, DateTime,Time
             :datetime
           when Arel::Attributes::Attribute
-            ArelExtensions::column_of(obj.relation.table_name, obj.name.to_s)&.type || :string
+            ArelExtensions.column_of(obj.relation.table_name, obj.name.to_s)&.type || :string
           else
             :string
           end

--- a/lib/arel_extensions/nodes/case.rb
+++ b/lib/arel_extensions/nodes/case.rb
@@ -57,7 +57,7 @@ module ArelExtensions
           when Date, DateTime,Time
             :datetime
           when Arel::Attributes::Attribute
-            ArelExtensions.column_of(obj.relation.table_name, obj.name.to_s)&.type || :string
+            Arel.column_of(obj.relation.table_name, obj.name.to_s)&.type || :string
           else
             :string
           end

--- a/lib/arel_extensions/nodes/function.rb
+++ b/lib/arel_extensions/nodes/function.rb
@@ -51,7 +51,7 @@ module ArelExtensions
       def type_of_attribute(att)
         case att
         when Arel::Attributes::Attribute
-          ArelExtensions.column_of(att.relation.table_name, att.name.to_s)&.type || att
+          Arel.column_of(att.relation.table_name, att.name.to_s)&.type || att
         when ArelExtensions::Nodes::Function
           att.return_type
           #        else

--- a/lib/arel_extensions/nodes/function.rb
+++ b/lib/arel_extensions/nodes/function.rb
@@ -51,7 +51,7 @@ module ArelExtensions
       def type_of_attribute(att)
         case att
         when Arel::Attributes::Attribute
-          ArelExtensions::column_of(att.relation.table_name, att.name.to_s)&.type || att
+          ArelExtensions.column_of(att.relation.table_name, att.name.to_s)&.type || att
         when ArelExtensions::Nodes::Function
           att.return_type
           #        else

--- a/lib/arel_extensions/visitors/oracle.rb
+++ b/lib/arel_extensions/visitors/oracle.rb
@@ -530,7 +530,7 @@ module ArelExtensions
         if element.is_a?(Time)
           ArelExtensions::Nodes::Format.new [element, '%H:%M:%S']
         elsif element.is_a?(Arel::Attributes::Attribute)
-          col = ArelExtensions.column_of(element.relation.table_name, element.name.to_s)
+          col = Arel.column_of(element.relation.table_name, element.name.to_s)
           if col && (col.type == :time)
             ArelExtensions::Nodes::Format.new [element, '%H:%M:%S']
           else

--- a/lib/arel_extensions/visitors/oracle.rb
+++ b/lib/arel_extensions/visitors/oracle.rb
@@ -530,7 +530,7 @@ module ArelExtensions
         if element.is_a?(Time)
           ArelExtensions::Nodes::Format.new [element, '%H:%M:%S']
         elsif element.is_a?(Arel::Attributes::Attribute)
-          col = ArelExtensions::column_of(element.relation.table_name, element.name.to_s)
+          col = ArelExtensions.column_of(element.relation.table_name, element.name.to_s)
           if col && (col.type == :time)
             ArelExtensions::Nodes::Format.new [element, '%H:%M:%S']
           else

--- a/lib/arel_extensions/visitors/sqlite.rb
+++ b/lib/arel_extensions/visitors/sqlite.rb
@@ -327,7 +327,7 @@ module ArelExtensions
         if element.is_a?(Time)
           return Arel::Nodes::NamedFunction.new('STRFTIME',[element, '%H:%M:%S'])
         elsif element.is_a?(Arel::Attributes::Attribute)
-          col = ArelExtensions.column_of(element.relation.table_name, element.name.to_s)
+          col = Arel.column_of(element.relation.table_name, element.name.to_s)
           if col && (col.type == :time)
             return Arel::Nodes::NamedFunction.new('STRFTIME',[element, '%H:%M:%S'])
           else

--- a/lib/arel_extensions/visitors/sqlite.rb
+++ b/lib/arel_extensions/visitors/sqlite.rb
@@ -1,5 +1,3 @@
-require 'arel_extensions/helpers'
-
 module ArelExtensions
   module Visitors
     class Arel::Visitors::SQLite
@@ -329,7 +327,7 @@ module ArelExtensions
         if element.is_a?(Time)
           return Arel::Nodes::NamedFunction.new('STRFTIME',[element, '%H:%M:%S'])
         elsif element.is_a?(Arel::Attributes::Attribute)
-          col = ArelExtensions::column_of(element.relation.table_name, element.name.to_s)
+          col = ArelExtensions.column_of(element.relation.table_name, element.name.to_s)
           if col && (col.type == :time)
             return Arel::Nodes::NamedFunction.new('STRFTIME',[element, '%H:%M:%S'])
           else

--- a/test/with_ar/all_agnostic_test.rb
+++ b/test/with_ar/all_agnostic_test.rb
@@ -107,6 +107,14 @@ module ArelExtensions
         end
       end
 
+      # Connection and column info
+      def test_column_of
+        assert_nil ArelExtensions.column_of('chupa', 'maflavla'), 'Non-existent table and column should return nil'
+        assert_nil ArelExtensions.column_of('chupa', 'updated_at'), 'Non-existent table but existent column should return nil'
+        assert_nil ArelExtensions.column_of('user_tests', 'maflavla'), 'Existent table but non-existent column should return nil'
+        assert_equal 'updated_at', ArelExtensions.column_of("user_tests", 'updated_at').name, 'An existing column name should be returned'
+      end
+
       # Math Functions
       def test_classical_arel
         assert_in_epsilon 42.16, t(@laure, @score + 22), 0.01

--- a/test/with_ar/all_agnostic_test.rb
+++ b/test/with_ar/all_agnostic_test.rb
@@ -109,10 +109,10 @@ module ArelExtensions
 
       # Connection and column info
       def test_column_of
-        assert_nil ArelExtensions.column_of('chupa', 'maflavla'), 'Non-existent table and column should return nil'
-        assert_nil ArelExtensions.column_of('chupa', 'updated_at'), 'Non-existent table but existent column should return nil'
-        assert_nil ArelExtensions.column_of('user_tests', 'maflavla'), 'Existent table but non-existent column should return nil'
-        assert_equal 'updated_at', ArelExtensions.column_of("user_tests", 'updated_at').name, 'An existing column name should be returned'
+        assert_nil Arel.column_of('chupa', 'maflavla'), 'Non-existent table and column should return nil'
+        assert_nil Arel.column_of('chupa', 'updated_at'), 'Non-existent table but existent column should return nil'
+        assert_nil Arel.column_of('user_tests', 'maflavla'), 'Existent table but non-existent column should return nil'
+        assert_equal 'updated_at', Arel.column_of("user_tests", 'updated_at').name, 'An existing column name should be returned'
       end
 
       # Math Functions


### PR DESCRIPTION
Never throw exceptions, always return `nil` instead. This is useful for subqueries.