### PR TITLE
Feature: Add RollUp

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -73,7 +73,7 @@ jobs:
           sudo apt-get update -q
           sudo apt-get install -y freetds-dev
       - name: Update system-wide gems
-        run: gem update --system
+        run: gem update --system --no-document
       - name: Download gem from build job
         uses: actions/download-artifact@v2
         with:
@@ -121,7 +121,7 @@ jobs:
           sudo apt-get update -q
           sudo apt-get install -y freetds-dev
       - name: Update system-wide gems
-        run: gem update --system
+        run: gem update --system --no-document
       - name: Download gem from build job
         uses: actions/download-artifact@v2
         with:
@@ -192,7 +192,7 @@ jobs:
           sudo apt-get update -q
           sudo apt-get install -y freetds-dev
       - name: Update system-wide gems
-        run: gem update --system
+        run: gem update --system --no-document
       - name: Download gem from build job
         uses: actions/download-artifact@v2
         with:
@@ -257,7 +257,7 @@ jobs:
           sudo apt-get update -q
           sudo apt-get install -y freetds-dev
       - name: Update system-wide gems
-        run: gem update --system
+        run: gem update --system --no-document
       - name: Download gem from build job
         uses: actions/download-artifact@v2
         with:
@@ -322,7 +322,7 @@ jobs:
           install: sqlengine, sqlclient, sqlpackage, localdb
           sa-password: Password12!
       - name: Update system-wide gems
-        run: gem update --system
+        run: gem update --system --no-document
       - name: Download gem from build job
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,46 +6,8 @@ name: Build and Test
 on: [push, pull_request]
 
 jobs:
-  job_build_gem:
-    name: build
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        ruby: [3.1, 3.0, 2.7, 2.5, jruby-9.2, jruby-9.3]
-        rails: [7, 6_1, 6, 5_2]
-        exclude: [
-          {ruby: 3.1,       rails: 6  },
-          {ruby: 3.1,       rails: 5_2},
-          {ruby: 3.0,       rails: 6  },
-          {ruby: 3.0,       rails: 5_2},
-          {ruby: 2.7,       rails: 5_2},
-          {ruby: 2.5,       rails: 7  },
-          {ruby: jruby-9.2, rails: 7  },
-          {ruby: jruby-9.3, rails: 7  },
-        ]
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-      - name: Setup gemspec
-        if: ${{ matrix.rails != '5_2' }}
-        run: |
-          cp ./gemspecs/arel_extensions-v2.gemspec ./arel_extensions.gemspec
-          cp ./version_v2.rb lib/arel_extensions/version.rb
-          cp ./gemfiles/rails${{ matrix.rails }}.gemfile ./Gemfile
-      - name: Build source gem
-        run: gem build arel_extensions.gemspec
-      - name: Upload source gem
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ matrix.ruby }}-${{ matrix.rails }}-gem
-          path: "*.gem"
-
   job_test_to_sql:
     name: test to_sql
-    needs: job_build_gem
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -74,10 +36,6 @@ jobs:
           sudo apt-get install -y freetds-dev
       - name: Update system-wide gems
         run: gem update --system --no-document
-      - name: Download gem from build job
-        uses: actions/download-artifact@v2
-        with:
-          name: ${{ matrix.ruby }}-${{ matrix.rails }}-gem
       - name: Setup Gemfile
         if: ${{ matrix.rails != '5_2' }}
         run: |
@@ -93,7 +51,6 @@ jobs:
 
   job_test_sqlite:
     name: test sqlite
-    needs: job_build_gem
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -122,10 +79,6 @@ jobs:
           sudo apt-get install -y freetds-dev
       - name: Update system-wide gems
         run: gem update --system --no-document
-      - name: Download gem from build job
-        uses: actions/download-artifact@v2
-        with:
-          name: ${{ matrix.ruby }}-${{ matrix.rails }}-gem
       - name: Setup Gemfile
         if: ${{ matrix.rails != '5_2' }}
         run: |
@@ -141,7 +94,6 @@ jobs:
 
   job_test_postgres:
     name: test postgres
-    needs: job_build_gem
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -193,10 +145,6 @@ jobs:
           sudo apt-get install -y freetds-dev
       - name: Update system-wide gems
         run: gem update --system --no-document
-      - name: Download gem from build job
-        uses: actions/download-artifact@v2
-        with:
-          name: ${{ matrix.ruby }}-${{ matrix.rails }}-gem
       - name: Setup Gemfile
         if: ${{ matrix.rails != '5_2' }}
         run: |
@@ -215,7 +163,6 @@ jobs:
 
   job_test_mysql:
     name: test mysql
-    needs: job_build_gem
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -258,10 +205,6 @@ jobs:
           sudo apt-get install -y freetds-dev
       - name: Update system-wide gems
         run: gem update --system --no-document
-      - name: Download gem from build job
-        uses: actions/download-artifact@v2
-        with:
-          name: ${{ matrix.ruby }}-${{ matrix.rails }}-gem
       - name: Setup Gemfile
         if: ${{ matrix.rails != '5_2' }}
         run: |
@@ -283,7 +226,6 @@ jobs:
 
   job_test_mssql:
     name: test mssql on linux
-    needs: job_build_gem
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -323,10 +265,6 @@ jobs:
           sa-password: Password12!
       - name: Update system-wide gems
         run: gem update --system --no-document
-      - name: Download gem from build job
-        uses: actions/download-artifact@v2
-        with:
-          name: ${{ matrix.ruby }}-${{ matrix.rails }}-gem
       - name: Setup Gemfile
         if: ${{ matrix.rails != '5_2' }}
         run: |

--- a/gemspecs/arel_extensions-v1.gemspec
+++ b/gemspecs/arel_extensions-v1.gemspec
@@ -23,6 +23,5 @@ Gem::Specification.new do |s|
   s.add_dependency('arel', '>= 6.0')
 
   s.add_development_dependency('minitest', '~> 5.9')
-  s.add_development_dependency('rdoc', '>= 6.3.1')
   s.add_development_dependency('rake', '~> 12.3.3')
 end

--- a/gemspecs/arel_extensions-v2.gemspec
+++ b/gemspecs/arel_extensions-v2.gemspec
@@ -23,6 +23,5 @@ Gem::Specification.new do |s|
   s.add_dependency('activerecord', '>= 6.0')
 
   s.add_development_dependency('minitest', '~> 5.9')
-  s.add_development_dependency('rdoc', '>= 6.3.1')
   s.add_development_dependency('rake', '~> 12.3.3')
 end

--- a/lib/arel_extensions.rb
+++ b/lib/arel_extensions.rb
@@ -132,6 +132,10 @@ module Arel
     ArelExtensions::Nodes::Rand.new
   end
 
+  def self.rollup(*args)
+    Arel::Nodes::RollUp.new(args)
+  end
+
   def self.shorten s
     Base64.urlsafe_encode64(Digest::MD5.new.digest(s)).tr('=', '').tr('-', '_')
   end

--- a/lib/arel_extensions.rb
+++ b/lib/arel_extensions.rb
@@ -281,4 +281,14 @@ class Arel::Attributes::Attribute
     collector = engine.connection.visitor.accept self, collector
     collector.value
   end
+
+  def rollup
+    Arel::Nodes::RollUp.new([self])
+  end
+end
+
+class Arel::Nodes::Node
+  def rollup
+    Arel::Nodes::RollUp.new([self])
+  end
 end

--- a/lib/arel_extensions/visitors/mssql.rb
+++ b/lib/arel_extensions/visitors/mssql.rb
@@ -487,6 +487,11 @@ module ArelExtensions
         collector
       end
 
+      def visit_Arel_Nodes_RollUp(o, collector)
+        collector << "ROLLUP"
+        grouping_array_or_grouping_element o, collector
+      end
+
       # TODO;
       def visit_ArelExtensions_Nodes_GroupConcat o, collector
         collector << '(STRING_AGG('
@@ -646,6 +651,18 @@ module ArelExtensions
         end
         collector << ')'
         collector
+      end
+
+      # Utilized by GroupingSet, Cube & RollUp visitors to
+      # handle grouping aggregation semantics
+      def grouping_array_or_grouping_element(o, collector)
+        if o.expr.is_a? Array
+          collector << "( "
+          visit o.expr, collector
+          collector << " )"
+        else
+          visit o.expr, collector
+        end
       end
     end
   end

--- a/lib/arel_extensions/visitors/mysql.rb
+++ b/lib/arel_extensions/visitors/mysql.rb
@@ -138,6 +138,11 @@ module ArelExtensions
         collector
       end
 
+      def visit_Arel_Nodes_RollUp(o, collector)
+        visit o.expr, collector
+        collector << " WITH ROLLUP"
+      end
+
       def visit_ArelExtensions_Nodes_GroupConcat o, collector
         collector << 'GROUP_CONCAT('
         collector = visit o.left, collector

--- a/lib/arel_extensions/visitors/oracle.rb
+++ b/lib/arel_extensions/visitors/oracle.rb
@@ -126,6 +126,11 @@ module ArelExtensions
       collector
       end
 
+      def visit_Arel_Nodes_RollUp(o, collector)
+        collector << "ROLLUP"
+        grouping_array_or_grouping_element o, collector
+      end
+
       def visit_ArelExtensions_Nodes_GroupConcat o, collector
         collector << '(LISTAGG('
         collector = visit o.left, collector
@@ -704,6 +709,18 @@ module ArelExtensions
         collector = visit o.right, collector
         collector << ')'
         collector
+      end
+
+      # Utilized by GroupingSet, Cube & RollUp visitors to
+      # handle grouping aggregation semantics
+      def grouping_array_or_grouping_element(o, collector)
+        if o.expr.is_a? Array
+          collector << "( "
+          visit o.expr, collector
+          collector << " )"
+        else
+          visit o.expr, collector
+        end
       end
     end
   end

--- a/test/with_ar/all_agnostic_test.rb
+++ b/test/with_ar/all_agnostic_test.rb
@@ -214,6 +214,19 @@ module ArelExtensions
         # hybrid
         q = User.select(at[:name], at[:score], at[:age].sum).group(at[:score], Arel.rollup([at[:name]]))
         assert q.to_a.length > 0
+
+        ## Using at[:col].rollup which is handy for single column rollups
+
+        # simple
+        q = User.select(at[:name], at[:age].sum).group(at[:name].rollup)
+        assert q.to_a.length > 0
+
+        q = User.select(at[:name], at[:score], at[:age].sum).group(at[:name].rollup, at[:score].rollup)
+        assert q.to_a.length > 0
+
+        # hybrid
+        q = User.select(at[:name], at[:score], at[:age].sum).group(at[:name], at[:score].rollup)
+        assert q.to_a.length > 0
       end
 
       # String Functions

--- a/test/with_ar/all_agnostic_test.rb
+++ b/test/with_ar/all_agnostic_test.rb
@@ -186,6 +186,22 @@ module ArelExtensions
         assert User.group(:score).count(:id).values.all?{|e| !e.nil?}
       end
 
+      def test_rollup
+        skip "sqlite not supported" if $sqlite
+        at = User.arel_table
+        # single
+        q = User.select(at[:name], at[:age].sum).group(Arel::Nodes::RollUp.new([at[:name]]))
+        assert q.to_a.length > 0
+
+        # multi
+        q = User.select(at[:name], at[:score], at[:age].sum).group(Arel::Nodes::RollUp.new([at[:score], at[:name]]))
+        assert q.to_a.length > 0
+
+        # hybrid
+        q = User.select(at[:name], at[:score], at[:age].sum).group(at[:score], Arel::Nodes::RollUp.new([at[:name]]))
+        assert q.to_a.length > 0
+      end
+
       # String Functions
       def test_concat
         assert_equal 'Camille Camille', t(@camille, @name + ' ' + @name)

--- a/test/with_ar/all_agnostic_test.rb
+++ b/test/with_ar/all_agnostic_test.rb
@@ -200,6 +200,20 @@ module ArelExtensions
         # hybrid
         q = User.select(at[:name], at[:score], at[:age].sum).group(at[:score], Arel::Nodes::RollUp.new([at[:name]]))
         assert q.to_a.length > 0
+
+        ## Using Arel.rollup which is less verbose than the original way
+
+        # simple
+        q = User.select(at[:name], at[:age].sum).group(Arel.rollup(at[:name]))
+        assert q.to_a.length > 0
+
+        # multi
+        q = User.select(at[:name], at[:score], at[:age].sum).group(Arel.rollup([at[:score], at[:name]]))
+        assert q.to_a.length > 0
+
+        # hybrid
+        q = User.select(at[:name], at[:score], at[:age].sum).group(at[:score], Arel.rollup([at[:name]]))
+        assert q.to_a.length > 0
       end
 
       # String Functions


### PR DESCRIPTION
Arel already defines Rollup for Postgres.

This patch adds support for MySQL/MSSQL/ORACLE.