### PR TITLE
Better `format` + `formatted_date`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,13 +1,30 @@
-# Release
+# News
 
-## Bug Fixes
+## Current Release
+
+### New Features
+
+- `o.format_date` as an alternative to `o.format`
+  The actual behavior of `format` is inconsistent across DB vendors: in mysql we
+  can format dates and numbers with it, and in the other ones we only format
+  dates.
+  
+  We're planning on normalizing this behavior. We want `format` to "cleverly"
+  format dates or numbers, and `format_date` / `format_number` to strictly
+  format dates / numbers.
+  
+  The introduction of `format_date` is the first step in this direction.
+
+## Release v2.1.6/v1.3.6
+
+### Bug Fixes
 
 - This used to fail.
   ```
   Arel.when(a).then(b).format('%Y-%m-%d')
   ```
 
-## New Features
+### New Features
 
 - `o.present`, a synonym for `o.not_blank`
 - `o.coalesce_blank(a, b, c)`

--- a/lib/arel_extensions/date_duration.rb
+++ b/lib/arel_extensions/date_duration.rb
@@ -1,4 +1,5 @@
 require 'arel_extensions/nodes/format'
+require 'arel_extensions/nodes/formatted_date'
 require 'arel_extensions/nodes/duration'
 require 'arel_extensions/nodes/wday'
 
@@ -42,6 +43,10 @@ module ArelExtensions
 
     def format(tpl, time_zone = nil)
       ArelExtensions::Nodes::Format.new [self, tpl, time_zone]
+    end
+
+    def format_date(tpl, time_zone = nil)
+      ArelExtensions::Nodes::FormattedDate.new [self, tpl, time_zone]
     end
   end
 end

--- a/lib/arel_extensions/nodes/formatted_date.rb
+++ b/lib/arel_extensions/nodes/formatted_date.rb
@@ -1,0 +1,42 @@
+require 'strscan'
+
+module ArelExtensions
+  module Nodes
+    class FormattedDate < Function
+      RETURN_TYPE = :string
+
+      attr_accessor :col_type, :iso_format, :time_zone
+
+      def initialize expr
+        col = expr[0]
+        @iso_format = convert_format(expr[1])
+        @time_zone  = expr[2]
+        @col_type = type_of_attribute(col)
+        super [col, convert_to_string_node(@iso_format)]
+      end
+
+      private
+
+      # Address portability issues with some of the formats.
+      def convert_format(fmt)
+        s = StringScanner.new fmt
+        res = StringIO.new
+        while !s.eos?
+          res <<
+            case
+            when s.scan(/%D/)    then '%m/%d/%y'
+            when s.scan(/%F/)    then '%Y-%m-%d'
+            when s.scan(/%R/)    then '%H:%M'
+            when s.scan(/%r/)    then '%I:%M:%S %p'
+            when s.scan(/%T/)    then '%H:%M:%S'
+            when s.scan(/%v/)    then '%e-%b-%Y'
+
+            when s.scan(/[^%]+/) then s.matched
+            when s.scan(/./)     then s.matched
+            end
+        end
+        res.string
+      end
+    end
+  end
+end

--- a/lib/arel_extensions/visitors/mssql.rb
+++ b/lib/arel_extensions/visitors/mssql.rb
@@ -355,6 +355,10 @@ module ArelExtensions
       end
 
       def visit_ArelExtensions_Nodes_Format o, collector
+        visit_ArelExtensions_Nodes_FormattedDate o, collector
+      end
+
+      def visit_ArelExtensions_Nodes_FormattedDate o, collector
         f = ArelExtensions::Visitors::strftime_to_format(o.iso_format, LOADED_VISITOR::DATE_FORMAT_DIRECTIVES)
         if fmt = LOADED_VISITOR::DATE_CONVERT_FORMATS[f]
           collector << "CONVERT(VARCHAR(#{f.length})"

--- a/lib/arel_extensions/visitors/mysql.rb
+++ b/lib/arel_extensions/visitors/mysql.rb
@@ -258,9 +258,11 @@ module ArelExtensions
         # In this case, `o.col_type` is `nil` but we have a legitimate type in
         # the expression to be formatted.  The following is a best effort to
         # infer the proper type.
+        first = o.expressions[0]
         type =
-          o.col_type.nil? && !o.expressions[0]&.return_type.nil? \
-          ? o.expressions[0]&.return_type \
+          o.col_type.nil? \
+            && (first.respond_to?(:return_type) && !first&.return_type.nil?) \
+          ? first&.return_type \
           : o.col_type
 
         case type

--- a/lib/arel_extensions/visitors/mysql.rb
+++ b/lib/arel_extensions/visitors/mysql.rb
@@ -267,26 +267,7 @@ module ArelExtensions
 
         case type
         when :date, :datetime, :time
-          fmt = ArelExtensions::Visitors::strftime_to_format(o.iso_format, DATE_FORMAT_DIRECTIVES)
-          collector << 'DATE_FORMAT('
-          collector << 'CONVERT_TZ(' if o.time_zone
-          collector = visit o.left, collector
-          case o.time_zone
-          when Hash
-            src_tz, dst_tz = o.time_zone.first
-            collector << COMMA
-            collector = visit Arel.quoted(src_tz), collector
-            collector << COMMA
-            collector = visit Arel.quoted(dst_tz), collector
-            collector << ')'
-          when String
-            collector << COMMA << "'UTC'" << COMMA
-            collector = visit Arel.quoted(o.time_zone), collector
-            collector << ')'
-          end
-          collector << COMMA
-          collector = visit Arel.quoted(fmt), collector
-          collector << ')'
+          visit_ArelExtensions_Nodes_FormattedDate o, collector
         when :integer, :float, :decimal
           collector << 'FORMAT('
           collector = visit o.left, collector
@@ -299,6 +280,29 @@ module ArelExtensions
           collector = visit o.left, collector
         end
         collector
+      end
+
+      def visit_ArelExtensions_Nodes_FormattedDate o, collector
+        fmt = ArelExtensions::Visitors::strftime_to_format(o.iso_format, DATE_FORMAT_DIRECTIVES)
+        collector << 'DATE_FORMAT('
+        collector << 'CONVERT_TZ(' if o.time_zone
+        collector = visit o.left, collector
+        case o.time_zone
+        when Hash
+          src_tz, dst_tz = o.time_zone.first
+          collector << COMMA
+          collector = visit Arel.quoted(src_tz), collector
+          collector << COMMA
+          collector = visit Arel.quoted(dst_tz), collector
+          collector << ')'
+        when String
+          collector << COMMA << "'UTC'" << COMMA
+          collector = visit Arel.quoted(o.time_zone), collector
+          collector << ')'
+        end
+        collector << COMMA
+        collector = visit Arel.quoted(fmt), collector
+        collector << ')'
       end
 
       def visit_ArelExtensions_Nodes_DateDiff o, collector

--- a/lib/arel_extensions/visitors/oracle.rb
+++ b/lib/arel_extensions/visitors/oracle.rb
@@ -451,6 +451,10 @@ module ArelExtensions
       end
 
       def visit_ArelExtensions_Nodes_Format o, collector
+        visit_ArelExtensions_Nodes_FormattedDate o, collector
+      end
+
+      def visit_ArelExtensions_Nodes_FormattedDate o, collector
         fmt = ArelExtensions::Visitors::strftime_to_format(o.iso_format, DATE_FORMAT_DIRECTIVES)
         collector << 'TO_CHAR('
         collector << 'CAST(' if o.time_zone

--- a/lib/arel_extensions/visitors/postgresql.rb
+++ b/lib/arel_extensions/visitors/postgresql.rb
@@ -174,6 +174,10 @@ module ArelExtensions
       end
 
       def visit_ArelExtensions_Nodes_Format o, collector
+        visit_ArelExtensions_Nodes_FormattedDate o, collector
+      end
+
+      def visit_ArelExtensions_Nodes_FormattedDate o, collector
         fmt = ArelExtensions::Visitors::strftime_to_format(o.iso_format, DATE_FORMAT_DIRECTIVES)
         collector << 'TO_CHAR('
         collector << '(' if o.time_zone

--- a/lib/arel_extensions/visitors/to_sql.rb
+++ b/lib/arel_extensions/visitors/to_sql.rb
@@ -289,6 +289,26 @@ module ArelExtensions
         collector
       end
 
+      def visit_ArelExtensions_Nodes_FormattedDate o, collector
+        case o.col_type
+        when :date, :datetime, :time
+          collector << 'STRFTIME('
+          collector = visit o.right, collector
+          collector << COMMA
+          collector = visit o.left, collector
+          collector << ')'
+        when :integer, :float, :decimal
+          collector << 'FORMAT('
+          collector = visit o.left, collector
+          collector << COMMA
+          collector = visit o.right, collector
+          collector << ')'
+        else
+          collector = visit o.left, collector
+        end
+        collector
+      end
+
       # comparators
 
       def visit_ArelExtensions_Nodes_Cast o, collector


### PR DESCRIPTION
This PR does 2 things:

1. Fixes a bug in `Format` for mysql, where type inference can go wrong if `return_type` doesn't exist.
2. Introduce `format_date`, mirroring `format_number`