### PR TITLE
json: escape all the "popular" control characters

### DIFF
--- a/lib/arel_extensions/visitors/to_sql.rb
+++ b/lib/arel_extensions/visitors/to_sql.rb
@@ -9,7 +9,13 @@ module ArelExtensions
         Arel.quoted('"') \
         + expr
             .coalesce('')
-            .replace('\\', '\\\\').replace('"', '\"').replace("\n", '\n') \
+            .replace('\\', '\\\\')
+            .replace('"', '\"')
+            .replace("\b", '\b')
+            .replace("\f", '\f')
+            .replace("\n", '\n')
+            .replace("\r", '\r')
+            .replace("\t", '\t') \
         + '"'
       end
 

--- a/test/arelx_test_helper.rb
+++ b/test/arelx_test_helper.rb
@@ -12,10 +12,6 @@ end
 
 YELLOW = '33'
 
-def warn(msg)
-  $stderr.puts(colored(YELLOW, msg))
-end
-
 # Load gems specific to databases
 # NOTE:
 #     It's strongly advised to test each database on its own. Loading multiple

--- a/test/with_ar/all_agnostic_test.rb
+++ b/test/with_ar/all_agnostic_test.rb
@@ -680,10 +680,10 @@ module ArelExtensions
         assert_equal 0, User.where(@created_at.year.eq('2012')).count
         # Month
         assert_equal 5, t(@camille, @created_at.month).to_i
-        assert_equal 9, User.where(@created_at.month.eq('05')).count
+        assert_equal 10, User.where(@created_at.month.eq('05')).count
         # Week
         assert_equal(@env_db == 'mssql' ? 22 : 21, t(@arthur, @created_at.week).to_i)
-        assert_equal 9, User.where(@created_at.month.eq('05')).count
+        assert_equal 10, User.where(@created_at.month.eq('05')).count
         # Day
         assert_equal 23, t(@laure, @created_at.day).to_i
         assert_equal 0, User.where(@created_at.day.eq('05')).count


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc8259:

> All Unicode characters may be placed within the quotation marks,  except for the characters that MUST be escaped: quotation mark,  reverse solidus, and the control characters (U+0000 through U+001F).

We should also escape the remaining ones, using \u.


Where are the tests for this?