### PR TITLE
potsgres: default to UTC when formatting dates.

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -49,9 +49,6 @@ jobs:
         run: |
           sudo apt-get update -q
           sudo apt-get install -y freetds-dev
-      - name: Update system-wide gems
-        if: ${{ !contains(fromJson('["2.5", "jruby-9.2"]'), matrix.versions.ruby) }}
-        run: gem update --system --no-document
       - name: Setup Gemfile for arelx 2.x
         if: ${{ matrix.versions.arelx == 2 }}
         run: |
@@ -109,9 +106,6 @@ jobs:
         run: |
           sudo apt-get update -q
           sudo apt-get install -y freetds-dev
-      - name: Update system-wide gems
-        if: ${{ !contains(fromJson('["2.5", "jruby-9.2"]'), matrix.versions.ruby) }}
-        run: gem update --system --no-document
       - name: Setup Gemfile
         if: ${{ matrix.versions.arelx == 2 }}
         run: |
@@ -191,9 +185,6 @@ jobs:
         run: |
           sudo apt-get update -q
           sudo apt-get install -y freetds-dev
-      - name: Update system-wide gems
-        if: ${{ !contains(fromJson('["2.5", "jruby-9.2"]'), matrix.versions.ruby) }}
-        run: gem update --system --no-document
       - name: Setup Gemfile
         if: ${{ matrix.versions.arelx == 2 }}
         run: |
@@ -268,9 +259,6 @@ jobs:
         run: |
           sudo apt-get update -q
           sudo apt-get install -y freetds-dev
-      - name: Update system-wide gems
-        if: ${{ !contains(fromJson('["2.5", "jruby-9.2"]'), matrix.versions.ruby) }}
-        run: gem update --system --no-document
       - name: Setup Gemfile
         if: ${{ matrix.versions.arelx == 2 }}
         run: |
@@ -337,9 +325,6 @@ jobs:
           version: ${{ matrix.mssql }}
           install: sqlengine, sqlclient, sqlpackage, localdb
           sa-password: Password12!
-      - name: Update system-wide gems
-        if: ${{ !contains(fromJson('["2.5", "jruby-9.2"]'), matrix.versions.ruby) }}
-        run: gem update --system --no-document
       - name: Setup Gemfile
         if: ${{ matrix.versions.arelx == 2 }}
         run: |

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,17 +2,47 @@
 
 ## Current Release
 
+### Bug Fixes
+
+- Postgres:
+  - Datetime formatting in postgres now behaves like mysql: if the target
+    timezone is a string, we automatically consider that you're trying to
+    convert from `UTC`.
+  - Datetime casting will now automatically ask for a
+    `timestamp without timezone`, also aligning with the expected befavior
+    in mysql. This also makes casting work better with timezone conversion,
+    especially if you don't pass the timezone from which you're converting
+    to.
+    ```ruby
+    scope
+      .select(Arel.quoted('2022-02-01 10:42:00')
+      .cast(:datetime)
+      .format_date('%Y/%m/%d %H:%M:%S', 'Europe/Paris')
+      .as('res'))
+    ```
+    Will produce:
+    ```sql
+    SELECT TO_CHAR(
+        CAST('2022-02-01 10:42:00' AS timestamp without time zone) AT TIME ZONE 'UTC' AT TIME ZONE 'Europe/Paris',
+        'YYYY/MM/DD HH24:MI:SS'
+      )
+      AS "res"
+    -- …
+    ```
+
+## Release v2.1.7/v1.3.7
+
 ### New Features
 
 - `o.format_date` as an alternative to `o.format`
   The actual behavior of `format` is inconsistent across DB vendors: in mysql we
   can format dates and numbers with it, and in the other ones we only format
   dates.
-  
+
   We're planning on normalizing this behavior. We want `format` to "cleverly"
   format dates or numbers, and `format_date` / `format_number` to strictly
   format dates / numbers.
-  
+
   The introduction of `format_date` is the first step in this direction.
 
 ## Release v2.1.6/v1.3.6

--- a/README.md
+++ b/README.md
@@ -173,9 +173,9 @@ The second form accepts 2 kinds of values:
 
 ```ruby
 t[:birthdate].format('%Y/%m/%d %H:%M:%S', 'posix/Pacific/Tahiti')
-# => DATE_FORMAT(CONVERT_TZ(CAST(my_table.birthdate AS datetime), 'UTC', 'posix/Pacific/Tahiti'), '%Y/%m/%d %H:%i:%S')          ## MySQL
-# => TO_CHAR(CAST(my_table.birthdate AS timestamp with time zone) AT TIME ZONE 'posix/Pacific/Tahiti', 'YYYY/MM/DD HH24:MI:SS') ## PostgreSQL
-# => CONVERT(datetime, my_table.birthdate) AT TIME ZONE 'UTC' AT TIME ZONE N'posix/Pacific/Tahiti'                              ## SQL Server (& truncated for clarity)
+# => DATE_FORMAT(CONVERT_TZ(CAST(my_table.birthdate AS datetime), 'UTC', 'posix/Pacific/Tahiti'), '%Y/%m/%d %H:%i:%S')                             ## MySQL
+# => TO_CHAR(CAST(my_table.birthdate AS timestamp with time zone) AT TIME ZONE 'UTC' AT TIME ZONE 'posix/Pacific/Tahiti', 'YYYY/MM/DD HH24:MI:SS') ## PostgreSQL
+# => CONVERT(datetime, my_table.birthdate) AT TIME ZONE 'UTC' AT TIME ZONE N'posix/Pacific/Tahiti'                                                 ## SQL Server (& truncated for clarity)
 #                                                                            ^^^^^^^^^^^^^^^^^^^^ 🚨 Invalid timezone for SQL Server. Explanation below.
 ```
 

--- a/lib/arel_extensions.rb
+++ b/lib/arel_extensions.rb
@@ -121,6 +121,26 @@ module Arel
     )
   end
 
+  def self.json_true
+    res = Arel.grouping(Arel.quoted('true'))
+    res.instance_eval {
+      def return_type
+        :boolean
+      end
+    }
+    res
+  end
+
+  def self.json_false
+    res = Arel.grouping(Arel.quoted('false'))
+    res.instance_eval {
+      def return_type
+        :boolean
+      end
+    }
+    res
+  end
+
   # The NULL literal.
   def self.null
     Arel.quoted(nil)

--- a/lib/arel_extensions/visitors/postgresql.rb
+++ b/lib/arel_extensions/visitors/postgresql.rb
@@ -392,7 +392,7 @@ module ArelExtensions
           when :number, :decimal, :float
             'numeric'
           when :datetime
-            'timestamp with time zone'
+            'timestamp without time zone'
           when :date
             'date'
           when :binary

--- a/lib/arel_extensions/visitors/postgresql.rb
+++ b/lib/arel_extensions/visitors/postgresql.rb
@@ -190,7 +190,7 @@ module ArelExtensions
           collector << ' AT TIME ZONE '
           collector = visit Arel.quoted(dst_tz), collector
         when String
-          collector << ') AT TIME ZONE '
+          collector << ") AT TIME ZONE 'UTC' AT TIME ZONE "
           collector = visit Arel.quoted(o.time_zone), collector
         end
         collector << COMMA

--- a/test/with_ar/all_agnostic_test.rb
+++ b/test/with_ar/all_agnostic_test.rb
@@ -501,7 +501,7 @@ module ArelExtensions
           #
           # MySQL is happy to consider that times by default are in UTC.
           assert_equal '2014/03/03 13:42:00', t(@lucas, @updated_at.send(method, '%Y/%m/%d %H:%M:%S', {tz['utc'] => tz['paris']}))
-          refute_equal '2014/03/03 13:42:00', t(@lucas, @updated_at.send(method, '%Y/%m/%d %H:%M:%S', tz['paris'])) if !['mysql'].include?(ENV['DB'])
+          refute_equal '2014/03/03 13:42:00', t(@lucas, @updated_at.send(method, '%Y/%m/%d %H:%M:%S', tz['paris'])) if !%w[mysql postgresql].include?(ENV['DB'])
 
           # Winter/Summer time
           assert_equal '2014/08/03 14:42:00', t(@lucas, (@updated_at + 5.months).send(method, '%Y/%m/%d %H:%M:%S', {tz['utc'] => tz['paris']}))


### PR DESCRIPTION
In this PR 2 things happened for postgres:

1. Casting to timestamps is done through `timestamp without timezone`.
2. Converting timezones, when we only specify a string (the destination), considers that we're starting from UTC, and doesn't leave it to interpretation. If you want to specify the starting timezone, pass a hash.