### PR TITLE
Mssql date time literal support

### DIFF
--- a/lib/arel_extensions/visitors/mssql.rb
+++ b/lib/arel_extensions/visitors/mssql.rb
@@ -118,7 +118,7 @@ module ArelExtensions
           when Numeric, ActiveSupport::Duration
             value.to_s
           when Date, Time
-            "#{quoted_date(value)}"
+            quoted_date(value)
           when Class
             "'#{value}'"
           else

--- a/lib/arel_extensions/visitors/mssql.rb
+++ b/lib/arel_extensions/visitors/mssql.rb
@@ -69,20 +69,22 @@ module ArelExtensions
         end
 
         def quoted_date(value)
+          format_str = '%Y-%m-%d'
           if value.acts_like?(:time)
             if ActiveRecord::Base.default_timezone == :utc
               value = value.getutc if value.respond_to?(:getutc) && !value.utc?
             else
               value = value.getlocal if value.respond_to?(:getlocal)
             end
+            format_str = '%Y-%m-%dT%H:%M:%S.%L'
           end
-
-          result = value.to_s(:db)
+          result = value.strftime(format_str)
           if value.respond_to?(:usec) && value.usec > 0
             result << '.' << sprintf('%06d', value.usec)
           else
             result
           end
+          "CAST('#{result}' AS #{value.acts_like?(:time) ? "datetime" : "date"})"
         end
 
         def quoted_true
@@ -116,7 +118,7 @@ module ArelExtensions
           when Numeric, ActiveSupport::Duration
             value.to_s
           when Date, Time
-            "'#{quoted_date(value)}'"
+            "#{quoted_date(value)}"
           when Class
             "'#{value}'"
           else

--- a/test/real_db_test.rb
+++ b/test/real_db_test.rb
@@ -40,6 +40,7 @@ def setup_db
       t.column :created_at, :date
       t.column :updated_at, :date
       t.column :score, :decimal
+      t.column :updated_at, :datetime
   end
 end
 
@@ -53,11 +54,12 @@ end
 class ListTest < Minitest::Test
   def setup
     d = Date.new(2016, 05, 23)
+    dt = Time.new(2016, 05, 23, 12, 34, 56)
     setup_db
     User.create age: 5, name: 'Lucas', created_at: d, score: 20.16
     User.create age: 15, name: 'Sophie', created_at: d, score: 20.16
     User.create age: 20, name: 'Camille', created_at: d, score: 20.16
-    User.create age: 21, name: 'Arthur', created_at: d, score: 65.62
+    User.create age: 21, name: 'Arthur', created_at: d, score: 65.62, updated_at: dt
     u = User.create age: 23, name: 'Myung', created_at: d, score: 20.16
     @myung = User.where(id: u.id)
     User.create age: 25, name: 'Laure', created_at: d, score: 20.16
@@ -100,12 +102,15 @@ class ListTest < Minitest::Test
   end
 
   def test_date_date_comparator
-    d = Date.new(2016, 05, 24)
+    d = Date.new(2016, 05, 24) #after created_at in db
     assert_equal 8, User.where(User.arel_table[:age] < d).count
     assert_equal 0, User.where(User.arel_table[:age] > d).count
     assert_equal 0, User.where(User.arel_table[:age] == d).count
     d = Date.new(2016, 05, 23)
     assert_equal 8, User.where(User.arel_table[:age] == d).count
+    dt = Time.new(2016, 05, 23, 12, 35, 00) #after updated_at in db
+    assert_equal 1, User.where(User.arel_table[:update_at] < dt).count
+    assert_equal 0, User.where(User.arel_table[:update_at] > dt).count
   end
 
   def test_date_duration

--- a/test/real_db_test.rb
+++ b/test/real_db_test.rb
@@ -91,12 +91,21 @@ class ListTest < Minitest::Test
     end
   end
 
-  def test_Comparator
+  def test_comparator
     assert_equal 2, User.where(User.arel_table[:age] < 6).count
     assert_equal 2, User.where(User.arel_table[:age] <= 10).count
     assert_equal 3, User.where(User.arel_table[:age] > 20).count
     assert_equal 4, User.where(User.arel_table[:age] >= 20).count
     assert_equal 1, User.where(User.arel_table[:age] > 5).where(User.arel_table[:age] < 20).count
+  end
+
+  def test_date_date_comparator
+    d = Date.new(2016, 05, 24)
+    assert_equal 8, User.where(User.arel_table[:age] < d).count
+    assert_equal 0, User.where(User.arel_table[:age] > d).count
+    assert_equal 0, User.where(User.arel_table[:age] == d).count
+    d = Date.new(2016, 05, 23)
+    assert_equal 8, User.where(User.arel_table[:age] == d).count
   end
 
   def test_date_duration


### PR DESCRIPTION
Formatted date/datetime cannot be used in date operation in SqlServer.
This PR fixes it