### PR TITLE
Turn on SQL Server warnings only when necessary

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -3,7 +3,13 @@ name: Build and Test
 # Ruby + Rails Compatibility Matrix from here:
 # https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   job_test_to_sql:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # News
 
+- MS SQL: turn on warnings on requires only when necessary.
+
 ## Release v2.1.10/v1.3.10
 
 - MS SQL: add support for jruby 9.4 via [activerecord-jdbc-alt-adapter](https://rubygems.org/gems/activerecord-jdbc-alt-adapter/)

--- a/lib/arel_extensions/visitors.rb
+++ b/lib/arel_extensions/visitors.rb
@@ -13,6 +13,12 @@ if RUBY_PLATFORM == 'java' \
   rescue LoadError
     warn 'arel/visitors/sqlserver not found: MSSQL might not work correctly.'
   end
+elsif RUBY_PLATFORM != 'java' && Arel::VERSION.to_i < 10
+  begin
+    require 'arel_sqlserver'
+  rescue LoadError
+    warn 'arel_sqlserver not found: SQLServer Visitor might not work correctly.'
+  end
 end
 
 require 'arel_extensions/visitors/convert_format'
@@ -38,15 +44,6 @@ if defined?(Arel::Visitors::DepthFirst)
     def visit_Arel_SelectManager o
         visit o.ast
     end
-  end
-end
-
-# Especially required here, not inside the next if, for Arel < 6.
-if RUBY_PLATFORM != 'java'
-  begin
-    require 'arel_sqlserver'
-  rescue LoadError
-    warn 'gem arel_sqlserver not found: SQLServer Visitor might not work correctly.'
   end
 end
 

--- a/lib/arel_extensions/visitors.rb
+++ b/lib/arel_extensions/visitors.rb
@@ -4,7 +4,10 @@
 # 1. putting it inside the visitor or anywhere else will not
 #    guarantee its actual loading.
 # 2. it needs to load before arel_extensions/visitors.
-if RUBY_PLATFORM == 'java' && Gem::Specification.find { |g| g.name == 'jdbc-mssql' }
+if RUBY_PLATFORM == 'java' \
+  && RUBY_ENGINE == 'jruby' \
+  && (version = JRUBY_VERSION.split('.').map(&:to_i)) && version[0] == 9 && version[1] >= 4 \
+  && Gem::Specification.find { |g| g.name == 'jdbc-mssql' }
   begin
     require 'arel/visitors/sqlserver'
   rescue LoadError


### PR DESCRIPTION
Also contains an improvement on CI build: no more duplicates on PRs.