### PR TITLE
mssql: restrict date quoting to arel <= 6

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # News
 
+- MS SQL: restrict date-quoting to Arel <= 6 (Rails 4.2)
+
 ## Release v2.1.11/v1.3.11
 
 - MS SQL: turn on warnings on requires only when necessary.

--- a/lib/arel_extensions/visitors/mssql.rb
+++ b/lib/arel_extensions/visitors/mssql.rb
@@ -76,7 +76,7 @@ module ArelExtensions
       # The following is adapted from
       # https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
       #
-      if RUBY_PLATFORM == 'java'
+      if RUBY_PLATFORM == 'java' && Arel::VERSION.to_i <= 6
         def quote_string(s)
           s.gsub('\\', '\&\&').gsub("'", "''") # ' (for ruby-mode)
         end


### PR DESCRIPTION
This might be the cause of some issues with SQL Server with Rails > 4, inventing columns called TRUE.