### PR TITLE
Use warning module for deprecation warnings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## [unreleased]
 
+- Use Ruby's Warning categories for Ruby > 2 for deprecations warnings.
+
 ## Release v2.2.2/v1.4.2 (27-11-2024)
 
 - Fix deprecartion warnings for `==` and `!=`, showing the true location.

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## [unreleased]
 
 - Use Ruby's Warning categories for Ruby > 2 for deprecations warnings.
+- Fix a bug with group concat that didn't correctly check for the separator value.
 
 ## Release v2.2.2/v1.4.2 (27-11-2024)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## [unreleased]
 
+## Release v2.2.3/v1.4.3 (18-12-2024)
+
 - Use Ruby's Warning categories for Ruby > 2 for deprecations warnings.
 - Fix a bug with group concat that didn't correctly check for the separator value.
 

--- a/gemfiles/rails6_1.gemfile
+++ b/gemfiles/rails6_1.gemfile
@@ -28,6 +28,14 @@ group :development, :test do
   gem 'activerecord-jdbcsqlite3-adapter', platforms: :jruby
   gem 'jdbc-mssql', platforms: :jruby, require: true
   gem 'jdbc-sqlite3', platforms: :jruby
+
+  # Ruby 3.4+ removes the following gems from the standard distribution.
+  # Warnings are emitted from 3.3 .
+  if Gem::Version.create(RUBY_VERSION) >= Gem::Version.create('3.3.0')
+    gem 'base64'
+    gem 'bigdecimal'
+    gem 'mutex_m'
+  end
 end
 
 gemspec path: Dir.pwd

--- a/gemfiles/rails7.gemfile
+++ b/gemfiles/rails7.gemfile
@@ -28,6 +28,14 @@ group :development, :test do
   gem 'activerecord-jdbcmysql-adapter', platforms: :jruby
   gem 'activerecord-jdbcpostgresql-adapter', platforms: :jruby
   gem 'activerecord-jdbcsqlite3-adapter', platforms: :jruby
+
+  # Ruby 3.4+ removes the following gems from the standard distribution.
+  # Warnings are emitted from 3.3 .
+  if Gem::Version.create(RUBY_VERSION) >= Gem::Version.create('3.3.0')
+    gem 'base64'
+    gem 'bigdecimal'
+    gem 'mutex_m'
+  end
 end
 
 gemspec path: Dir.pwd

--- a/gemfiles/rails7_1.gemfile
+++ b/gemfiles/rails7_1.gemfile
@@ -29,6 +29,14 @@ group :development, :test do
   gem 'activerecord-jdbcmysql-adapter', platforms: :jruby
   gem 'activerecord-jdbcpostgresql-adapter', platforms: :jruby
   gem 'activerecord-jdbcsqlite3-adapter', platforms: :jruby
+
+  # Ruby 3.4+ removes the following gems from the standard distribution.
+  # Warnings are emitted from 3.3 .
+  if Gem::Version.create(RUBY_VERSION) >= Gem::Version.create('3.3.0')
+    gem 'base64'
+    gem 'bigdecimal'
+    gem 'mutex_m'
+  end
 end
 
 gemspec path: Dir.pwd

--- a/gemfiles/rails7_1.gemfile
+++ b/gemfiles/rails7_1.gemfile
@@ -22,6 +22,7 @@ group :development, :test do
   gem 'activerecord-oracle_enhanced-adapter', '~> 7.0.0' if ENV.has_key? 'ORACLE_HOME'
 
   # for JRuby
+  gem 'jar-dependencies', '0.4.1', platforms: :jruby
   gem 'jdbc-mssql', platforms: :jruby, require: true
   gem 'jdbc-sqlite3', platform: :jruby
   gem 'activerecord-jdbc-alt-adapter', '~> 71.0.0.alpha1', platform: :jruby, require: true

--- a/gemfiles/rails7_2.gemfile
+++ b/gemfiles/rails7_2.gemfile
@@ -28,6 +28,14 @@ group :development, :test do
   gem 'activerecord-jdbcmysql-adapter', platforms: :jruby
   gem 'activerecord-jdbcpostgresql-adapter', platforms: :jruby
   gem 'activerecord-jdbcsqlite3-adapter', platforms: :jruby
+
+  # Ruby 3.4+ removes the following gems from the standard distribution.
+  # Warnings are emitted from 3.3 .
+  if Gem::Version.create(RUBY_VERSION) >= Gem::Version.create('3.3.0')
+    gem 'base64'
+    gem 'bigdecimal'
+    gem 'mutex_m'
+  end
 end
 
 gemspec path: Dir.pwd

--- a/lib/arel_extensions.rb
+++ b/lib/arel_extensions.rb
@@ -52,6 +52,7 @@ if Gem::Version.new(Arel::VERSION) >= Gem::Version.new('7.1.0')
   end
 end
 
+require 'arel_extensions/warning'
 require 'arel_extensions/helpers'
 require 'arel_extensions/version'
 require 'arel_extensions/aliases'

--- a/lib/arel_extensions.rb
+++ b/lib/arel_extensions.rb
@@ -257,6 +257,7 @@ class Arel::SelectManager
   include ArelExtensions::SetFunctions
   include ArelExtensions::Nodes
 
+  remove_method(:as) if method_defined?(:as)
   def as table_name
     Arel::Nodes::TableAlias.new(self, table_name)
   end

--- a/lib/arel_extensions/attributes.rb
+++ b/lib/arel_extensions/attributes.rb
@@ -17,18 +17,15 @@ module ArelExtensions
     include ArelExtensions::NullFunctions
     include ArelExtensions::StringFunctions
     include ArelExtensions::Predications
+    include ArelExtensions::Warning
 
     def ==(other)
-      if Gem::Version.create(ArelExtensions::VERSION) >= Gem::Version.create('2.2')
-        warn("#{caller(1..1).first} arel_extensions: `==` is now deprecated and will be removed soon. Use `.eq` instead.")
-      end
+      deprecated 'Use `.eq` instead.' if Gem::Version.create(ArelExtensions::VERSION) >= Gem::Version.create('2.2')
       Arel::Nodes::Equality.new self, Arel.quoted(other, self)
     end
 
     def !=(other)
-      if Gem::Version.create(ArelExtensions::VERSION) >= Gem::Version.create('2.2')
-        warn("#{caller(1..1).first} arel_extensions: `!=` is now deprecated and will be removed soon. Use `.not_eq` instead.")
-      end
+      deprecated 'Use `.not_eq` instead.' if Gem::Version.create(ArelExtensions::VERSION) >= Gem::Version.create('2.2')
       Arel::Nodes::NotEqual.new self, Arel.quoted(other, self)
     end
   end

--- a/lib/arel_extensions/nodes/aggregate_function.rb
+++ b/lib/arel_extensions/nodes/aggregate_function.rb
@@ -4,8 +4,8 @@ module ArelExtensions
       attr_accessor :order, :group
 
       def initialize node, **opts
-        @order = Array(opts[:order]).map{|e| convert_to_node(e)}
-        @group = Array(opts[:group]).map{|e| convert_to_node(e)}
+        @order = Array.wrap(opts[:order]).map{|e| convert_to_node(e)}
+        @group = Array.wrap(opts[:group]).map{|e| convert_to_node(e)}
         super [node]
       end
     end

--- a/lib/arel_extensions/nodes/function.rb
+++ b/lib/arel_extensions/nodes/function.rb
@@ -1,5 +1,11 @@
 require 'arel_extensions/predications'
 
+# This is required for rails 6.1
+# See https://github.com/thoughtbot/shoulda-matchers/issues/335
+if !Array.respond_to?(:wrap)
+  require 'active_support/core_ext/array/wrap'
+end
+
 module ArelExtensions
   module Nodes
     class Function < Arel::Nodes::Function

--- a/lib/arel_extensions/nodes/rollup.rb
+++ b/lib/arel_extensions/nodes/rollup.rb
@@ -3,7 +3,7 @@
 
 begin
   Arel::Nodes.const_get('RollUp')
-rescue NameError => e
+rescue NameError => _
   module Arel
     module Nodes
       class RollUp < Arel::Nodes::Unary

--- a/lib/arel_extensions/string_functions.rb
+++ b/lib/arel_extensions/string_functions.rb
@@ -144,7 +144,7 @@ module ArelExtensions
     # concat elements of a group, separated by sep and ordered by a list of Ascending or Descending
     def group_concat(sep = nil, *orders, group: nil, order: nil)
       if orders.present?
-        warn("Warning: ArelExtensions: group_concat: you should now use the kwarg 'order' to specify an order in the group_concat.")
+        deprecated 'Use the kwarg `order` instead.', what: 'orders'
       end
       order_tabs = [orders].flatten.map{ |o|
         if o.is_a?(Arel::Nodes::Ascending) || o.is_a?(Arel::Nodes::Descending)

--- a/lib/arel_extensions/version.rb
+++ b/lib/arel_extensions/version.rb
@@ -1,3 +1,3 @@
 module ArelExtensions
-  VERSION = '2.2.2'.freeze
+  VERSION = '2.2.3'.freeze
 end

--- a/lib/arel_extensions/visitors/mssql.rb
+++ b/lib/arel_extensions/visitors/mssql.rb
@@ -608,13 +608,13 @@ module ArelExtensions
         grouping_array_or_grouping_element o, collector
       end
 
-      # TODO;
       def visit_ArelExtensions_Nodes_GroupConcat o, collector
         collector << '(STRING_AGG('
         collector = visit o.left, collector
         collector << Arel::Visitors::Oracle::COMMA
+        sep = o.separator.is_a?(Arel::Nodes::Quoted) ? o.separator.expr : o.separator
         collector =
-          if o.separator && o.separator != 'NULL'
+          if 'NULL' != sep
             visit o.separator, collector
           else
             visit Arel.quoted(','), collector

--- a/lib/arel_extensions/visitors/mysql.rb
+++ b/lib/arel_extensions/visitors/mysql.rb
@@ -55,7 +55,7 @@ module ArelExtensions
           collect_nodes_for o.windows, collector, " WINDOW "
 
           if o.respond_to?(:comment)
-            maybe_visit o.comment, collector 
+            maybe_visit o.comment, collector
           else
             collector
           end
@@ -199,7 +199,8 @@ module ArelExtensions
             collector = visit order, collector
           end
         end
-        if o.separator && o.separator != 'NULL'
+        sep = o.separator.is_a?(Arel::Nodes::Quoted) ? o.separator.expr : o.separator
+        if 'NULL' != sep
           collector << ' SEPARATOR '
           collector = visit o.separator, collector
         end

--- a/lib/arel_extensions/visitors/mysql.rb
+++ b/lib/arel_extensions/visitors/mysql.rb
@@ -24,42 +24,42 @@ module ArelExtensions
         end
       end
 
-        # The whole purpose of this override is to fix the behavior of RollUp.
-        # All other databases treat RollUp sanely, execpt MySQL which requires
-        # that it figures as the last element of a GROUP BY.
-        def visit_Arel_Nodes_SelectCore(o, collector)
-          collector << "SELECT"
+      # The whole purpose of this override is to fix the behavior of RollUp.
+      # All other databases treat RollUp sanely, execpt MySQL which requires
+      # that it figures as the last element of a GROUP BY.
+      def visit_Arel_Nodes_SelectCore(o, collector)
+        collector << "SELECT"
 
-          collector = collect_optimizer_hints(o, collector) if self.respond_to?(:collect_optimizer_hinsts)
-          collector = maybe_visit o.set_quantifier, collector
+        collector = collect_optimizer_hints(o, collector) if self.respond_to?(:collect_optimizer_hinsts)
+        collector = maybe_visit o.set_quantifier, collector
 
-          collect_nodes_for o.projections, collector, " "
+        collect_nodes_for o.projections, collector, " "
 
-          if o.source && !o.source.empty?
-            collector << " FROM "
-            collector = visit o.source, collector
-          end
-
-          # The actual work
-          groups = o.groups
-          rollup = groups.select { |g| g.expr.class == Arel::Nodes::RollUp }.map { |r| r.expr.value }
-          if rollup && !rollup.empty?
-            groups = o.groups.reject { |g| g.expr.class == Arel::Nodes::RollUp }
-            groups << Arel::Nodes::RollUp.new(rollup)
-          end
-          # FIN
-
-          collect_nodes_for o.wheres, collector, " WHERE ", " AND "
-          collect_nodes_for groups, collector, " GROUP BY "            # Look ma, I'm viring a group
-          collect_nodes_for o.havings, collector, " HAVING ", " AND "
-          collect_nodes_for o.windows, collector, " WINDOW "
-
-          if o.respond_to?(:comment)
-            maybe_visit o.comment, collector
-          else
-            collector
-          end
+        if o.source && !o.source.empty?
+          collector << " FROM "
+          collector = visit o.source, collector
         end
+
+        # The actual work
+        groups = o.groups
+        rollup = groups.select { |g| g.expr.class == Arel::Nodes::RollUp }.map { |r| r.expr.value }
+        if rollup && !rollup.empty?
+          groups = o.groups.reject { |g| g.expr.class == Arel::Nodes::RollUp }
+          groups << Arel::Nodes::RollUp.new(rollup)
+        end
+        # FIN
+
+        collect_nodes_for o.wheres, collector, " WHERE ", " AND "
+        collect_nodes_for groups, collector, " GROUP BY "            # Look ma, I'm viring a group
+        collect_nodes_for o.havings, collector, " HAVING ", " AND "
+        collect_nodes_for o.windows, collector, " WINDOW "
+
+        if o.respond_to?(:comment)
+          maybe_visit o.comment, collector
+        else
+          collector
+        end
+      end
 
       # Math functions
       def visit_ArelExtensions_Nodes_Log10 o, collector

--- a/lib/arel_extensions/visitors/oracle.rb
+++ b/lib/arel_extensions/visitors/oracle.rb
@@ -135,8 +135,9 @@ module ArelExtensions
         collector << '(LISTAGG('
         collector = visit o.left, collector
         collector << COMMA
+        sep = o.separator.is_a?(Arel::Nodes::Quoted) ? o.separator.expr : o.separator
         collector =
-          if o.separator && o.separator != 'NULL'
+          if 'NULL' != sep
             visit o.separator, collector
           else
             visit Arel.quoted(','), collector

--- a/lib/arel_extensions/visitors/postgresql.rb
+++ b/lib/arel_extensions/visitors/postgresql.rb
@@ -136,8 +136,9 @@ module ArelExtensions
         o.order = nil
         visit_Aggregate_For_AggregateFunction o, collector
         collector << COMMA
+        sep = o.separator.is_a?(Arel::Nodes::Quoted) ? o.separator.expr : o.separator
         collector =
-          if o.separator && o.separator != 'NULL'
+          if 'NULL' != sep
             visit o.separator, collector
           else
             visit Arel.quoted(','), collector

--- a/lib/arel_extensions/visitors/to_sql.rb
+++ b/lib/arel_extensions/visitors/to_sql.rb
@@ -112,7 +112,8 @@ module ArelExtensions
       def visit_ArelExtensions_Nodes_GroupConcat o, collector
         collector << 'GROUP_CONCAT('
         collector = visit o.left, collector
-        if o.separator && o.separator != 'NULL'
+        sep = o.separator.is_a?(Arel::Nodes::Quoted) ? o.separator.expr : o.separator
+        if 'NULL' != sep
           collector << COMMA
           collector = visit o.separator, collector
         end

--- a/lib/arel_extensions/warning.rb
+++ b/lib/arel_extensions/warning.rb
@@ -1,9 +1,12 @@
 module ArelExtensions
   module Warning
     def deprecated msg
-      what = caller_locations(1, 1).first.label
       kaller = caller(2..2).first
+      return if kaller.include?('lib/arel_extensions') && ENV['AREL_EXTENSIONS_IN_TEST'] != '1'
+
+      what = caller_locations(1, 1).first.label
       msg = "#{kaller}: arel_extensions: `#{what}` is now deprecated. #{msg}"
+
       if RUBY_VERSION.to_f >= 3.0
         warn msg, category: :deprecated
       else

--- a/lib/arel_extensions/warning.rb
+++ b/lib/arel_extensions/warning.rb
@@ -1,10 +1,10 @@
 module ArelExtensions
   module Warning
-    def deprecated msg
+    def deprecated msg, what: nil
       kaller = caller(2..2).first
       return if kaller.include?('lib/arel_extensions') && ENV['AREL_EXTENSIONS_IN_TEST'] != '1'
 
-      what = caller_locations(1, 1).first.label
+      what = caller_locations(1, 1).first.label if what.nil?
       msg = "#{kaller}: arel_extensions: `#{what}` is now deprecated. #{msg}"
 
       if RUBY_VERSION.to_f >= 3.0

--- a/lib/arel_extensions/warning.rb
+++ b/lib/arel_extensions/warning.rb
@@ -1,0 +1,14 @@
+module ArelExtensions
+  module Warning
+    def deprecated msg
+      what = caller_locations(1, 1).first.label
+      kaller = caller(2..2).first
+      msg = "#{kaller}: arel_extensions: `#{what}` is now deprecated. #{msg}"
+      if RUBY_VERSION.to_f >= 3.0
+        warn msg, category: :deprecated
+      else
+        warn msg
+      end
+    end
+  end
+end

--- a/test/arelx_test_helper.rb
+++ b/test/arelx_test_helper.rb
@@ -42,6 +42,22 @@ db_and_gem =
     }
   end
 
+module Warning
+  ARELX_IGNORED = [
+    'PG::Coder.new(hash)',
+    'rb_check_safe_obj',       # ruby 3.0
+    'rb_tainted_str_new',      # ruby 3.0
+    'Using the last argument', # ruby < 3.0
+  ].freeze
+
+  def self.warn(message)
+    return if ARELX_IGNORED.any? { |msg| message.include?(msg) }
+
+    super
+  end
+end
+
+
 def load_lib(gems)
   if gems && (RUBY_PLATFORM == 'java' || Arel::VERSION.to_i > 9)
     gems.each do |gem|

--- a/test/arelx_test_helper.rb
+++ b/test/arelx_test_helper.rb
@@ -6,6 +6,8 @@ require 'active_record'
 
 require 'support/fake_record'
 
+ENV['AREL_EXTENSIONS_IN_TEST'] = '1' # Useful for deprecation warnings.
+
 def colored(color, msg)
   /^xterm|-256color$/.match?(ENV['TERM']) ? "\x1b[#{color}m#{msg}\x1b[89m\x1b[0m" : "#{msg}"
 end

--- a/test/with_ar/all_agnostic_test.rb
+++ b/test/with_ar/all_agnostic_test.rb
@@ -242,10 +242,10 @@ module ArelExtensions
         assert_equal 'Lucas,Sophie', t(User.where(name: %w[Lucas Sophie]), @name.group_concat)
 
         skip 'No order in group_concat in SqlLite' if $sqlite
-        assert_equal 'Arthur,Lucas,Sophie', t(User.where(name: %w[Lucas Sophie Arthur]), @name.group_concat(',', @name.asc))
-        assert_equal 'Sophie,Lucas,Arthur', t(User.where(name: %w[Lucas Sophie Arthur]), @name.group_concat(',', @name.desc))
-        assert_equal 'Lucas,Sophie,Arthur', t(User.where(name: %w[Lucas Sophie Arthur]), @name.group_concat(',', [@score.asc, @name.asc]))
-        assert_equal 'Lucas,Sophie,Arthur', t(User.where(name: %w[Lucas Sophie Arthur]), @name.group_concat(',', @score.asc, @name.asc))
+        assert_equal 'Arthur,Lucas,Sophie', t(User.where(name: %w[Lucas Sophie Arthur]), @name.group_concat(',', order: @name.asc))
+        assert_equal 'Sophie,Lucas,Arthur', t(User.where(name: %w[Lucas Sophie Arthur]), @name.group_concat(',', order: @name.desc))
+        assert_equal 'Lucas,Sophie,Arthur', t(User.where(name: %w[Lucas Sophie Arthur]), @name.group_concat(',', order: [@score.asc, @name.asc]))
+        assert_equal 'Lucas,Sophie,Arthur', t(User.where(name: %w[Lucas Sophie Arthur]), @name.group_concat(',', order: [@score.asc, @name.asc]))
         assert_equal 'Lucas,Sophie,Arthur', t(User.where(name: %w[Lucas Sophie Arthur]), @name.group_concat(',', order: [@score.asc, @name.asc]))
       end
 

--- a/version_v1.rb
+++ b/version_v1.rb
@@ -1,3 +1,3 @@
 module ArelExtensions
-  VERSION = '1.4.2'.freeze
+  VERSION = '1.4.3'.freeze
 end

--- a/version_v2.rb
+++ b/version_v2.rb
@@ -1,3 +1,3 @@
 module ArelExtensions
-  VERSION = '2.2.2'.freeze
+  VERSION = '2.2.3'.freeze
 end


### PR DESCRIPTION
1. get rid of a lot of useless warnings polluting the test suite
2. fix a bug from group_concat.