### PR TITLE
Use ActiveSupport::Deprecation instead of Ruby's Warning

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 ## Release v2.2.3/v1.4.3 (18-12-2024)
 
-- Use Ruby's Warning categories for Ruby > 2 for deprecations warnings.
+- Use ActiveSupport's deprecation machinery instead of Ruby's Warning module.
 - Fix a bug with group concat that didn't correctly check for the separator value.
 
 ## Release v2.2.2/v1.4.2 (27-11-2024)

--- a/lib/arel_extensions/warning.rb
+++ b/lib/arel_extensions/warning.rb
@@ -1,17 +1,15 @@
 module ArelExtensions
+  def self.deprecator
+    @deprecator ||= ActiveSupport::Deprecation.new(ArelExtensions::VERSION, "arel_extensions")
+  end
+
   module Warning
     def deprecated msg, what: nil
       kaller = caller(2..2).first
       return if kaller.include?('lib/arel_extensions') && ENV['AREL_EXTENSIONS_IN_TEST'] != '1'
 
       what = caller_locations(1, 1).first.label if what.nil?
-      msg = "#{kaller}: arel_extensions: `#{what}` is now deprecated. #{msg}"
-
-      if RUBY_VERSION.to_f >= 3.0
-        warn msg, category: :deprecated
-      else
-        warn msg
-      end
+      ArelExtensions.deprecator.warn "#{kaller}: `#{what}` is now deprecated. #{msg}"
     end
   end
 end


### PR DESCRIPTION
Using ruby's Warning module was a wrong. ActiveRecords depends on ActiveSupport, and this is more proper especially for rails applications.