### PR TITLE
Fix optimizer hints never being emitted on MySQL

### DIFF
--- a/lib/arel_extensions/visitors/mysql.rb
+++ b/lib/arel_extensions/visitors/mysql.rb
@@ -33,7 +33,7 @@ module ArelExtensions
       def visit_Arel_Nodes_SelectCore(o, collector)
         collector << 'SELECT'
 
-        collector = collect_optimizer_hints(o, collector) if self.respond_to?(:collect_optimizer_hinsts)
+        collector = collect_optimizer_hints(o, collector) if self.respond_to?(:collect_optimizer_hints, true)
         collector = maybe_visit o.set_quantifier, collector
 
         collect_nodes_for o.projections, collector, ' '


### PR DESCRIPTION
### Why
I've found a typo which is stopping optimizer hints being applied in MySQL. This PR fixes it.

The guard checked `respond_to?(:collect_optimizer_hinsts)`, a misspelling of `collect_optimizer_hints`, so it was always false and the overridden `visit_Arel_Nodes_SelectCore` dropped optimizer hints from every `SELECT`.

### What
Fix the spelling, and also pass a second arg to `respond_to?`. This is because fixing the spelling alone is not enough: `collect_optimizer_hints` is a private method in `Arel::Visitors::ToSql`, so the check also needs `respond_to?(..., true)` to see it.

_I used Claude code to author this PR, but I've checked it manually against a production MySQL dataset, and this PR is all mine 🙂_