### PR TITLE
Improve Json values and unlock their tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.DS_Store
+*.jar
 *.lock
 *.swp
 .bundle

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
   no longer truncated at 30 characters (the default when only `varchar` is specified).
 - PostgreSQL: JSON creation from non-JSON text now encodes it (`to_jsonb` instead of a
   bare `::jsonb` cast), and `json.set(key, nil)` sets the JSON null member instead of the db's NULL.
+- PostgreSQL: an empty JSON array (`Arel.json([])`) is now rendered as `'[]'::jsonb`
+  instead of `to_jsonb(array[])`.
 
 ## Release v2.4.0/v1.6.0 (23-12-2025)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## [unreleased]
 
+- Fix a bug (crash) in Group Concat of MSSQL.
+
 ## Release v2.4.0/v1.6.0 (23-12-2025)
 
 - Drop supoprt for Ruby < 2.7.

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - Fix a bug (crash) in Group Concat of MSSQL.
 - Fix a crash when building a JSON document from numeric literal values (e.g. `Arel.json(col => 1)`), on sqlite and mssql.
+- MS SQL: string casts and MD5 input now use `varchar(MAX)`, so long strings are
+  no longer truncated at 30 characters (the default when only `varchar` is specified).
 
 ## Release v2.4.0/v1.6.0 (23-12-2025)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## [unreleased]
 
 - Fix a bug (crash) in Group Concat of MSSQL.
+- Fix a crash when building a JSON document from numeric literal values (e.g. `Arel.json(col => 1)`), on sqlite and mssql.
 
 ## Release v2.4.0/v1.6.0 (23-12-2025)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
   bare `::jsonb` cast), and `json.set(key, nil)` sets the JSON null member instead of the db's NULL.
 - PostgreSQL: an empty JSON array (`Arel.json([])`) is now rendered as `'[]'::jsonb`
   instead of `to_jsonb(array[])`.
+- JSON: Booleans (`true`/`false`) are now supported as JSON values, whether as literals
+  (`Arel.json({ col => true })`) or boolean columns (`Arel.json({ col => bool_col })`).
 
 ## Release v2.4.0/v1.6.0 (23-12-2025)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 - Fix a crash when building a JSON document from numeric literal values (e.g. `Arel.json(col => 1)`), on sqlite and mssql.
 - MS SQL: string casts and MD5 input now use `varchar(MAX)`, so long strings are
   no longer truncated at 30 characters (the default when only `varchar` is specified).
+- PostgreSQL: JSON creation from non-JSON text now encodes it (`to_jsonb` instead of a
+  bare `::jsonb` cast), and `json.set(key, nil)` sets the JSON null member instead of the db's NULL.
 
 ## Release v2.4.0/v1.6.0 (23-12-2025)
 

--- a/gemfiles/rails7_1.gemfile
+++ b/gemfiles/rails7_1.gemfile
@@ -20,7 +20,7 @@ group :development, :test do
   gem 'pg', '~> 1.5', platforms: [:mri]
   gem 'sqlite3', '~> 1.6', platforms: [:mri]
 
-  gem 'activerecord-sqlserver-adapter', '~> 7.1.0.beta1', platforms: %i[mri mingw x64_mingw mswin]
+  gem 'activerecord-sqlserver-adapter', '~> 7.1.0', platforms: %i[mri mingw x64_mingw mswin]
   gem 'tiny_tds', platforms: %i[mri mingw x64_mingw mswin]
   gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw]
 

--- a/lib/arel_extensions/nodes/function.rb
+++ b/lib/arel_extensions/nodes/function.rb
@@ -73,6 +73,8 @@ module ArelExtensions
           Arel.quoted(object.strftime('%H:%M:%S'), self)
         when MBSTRING, String, Symbol
           Arel.quoted(object.to_s)
+        when TrueClass, FalseClass
+          Arel.quoted(object)
         when Date
           Arel.quoted(object.to_s, self)
         when NilClass

--- a/lib/arel_extensions/nodes/json.rb
+++ b/lib/arel_extensions/nodes/json.rb
@@ -61,6 +61,8 @@ module ArelExtensions
       def type_of_node(v)
         if v.is_a?(Arel::Attributes::Attribute)
           type_of_attribute(v)
+        elsif v.is_a?(Numeric)
+          :numeric
         elsif v.respond_to?(:return_type)
           v.return_type
         elsif v.nil?

--- a/lib/arel_extensions/nodes/json.rb
+++ b/lib/arel_extensions/nodes/json.rb
@@ -58,11 +58,21 @@ module ArelExtensions
         end
       end
 
+      # A boolean literal, either bare (TrueClass/FalseClass) or wrapped in a Quoted node
+      # (which is how `convert_to_node` represents one after construction).
+      def boolean_literal?(v)
+        v.is_a?(TrueClass) \
+          || v.is_a?(FalseClass) \
+          || (v.is_a?(Arel::Nodes::Quoted) && [true, false].include?(v.expr))
+      end
+
       def type_of_node(v)
         if v.is_a?(Arel::Attributes::Attribute)
           type_of_attribute(v)
         elsif v.is_a?(Numeric)
           :numeric
+        elsif boolean_literal?(v)
+          :boolean
         elsif v.respond_to?(:return_type)
           v.return_type
         elsif v.nil?

--- a/lib/arel_extensions/predications.rb
+++ b/lib/arel_extensions/predications.rb
@@ -88,6 +88,8 @@ module ArelExtensions
         Arel.quoted(object.strftime('%H:%M:%S'), self)
       when String
         Arel.quoted(object)
+      when TrueClass, FalseClass
+        Arel.quoted(object)
       when Date
         Arel.quoted(object.to_s, self)
       when NilClass

--- a/lib/arel_extensions/visitors/mssql.rb
+++ b/lib/arel_extensions/visitors/mssql.rb
@@ -164,7 +164,7 @@ module ArelExtensions
       def visit_ArelExtensions_Nodes_Log10(o, collector)
         collector << 'LOG10('
         o.expressions.each_with_index { |arg, i|
-          collector << Arel::Visitors::ToSql::COMMA if i != 0
+          collector << LOADED_VISITOR::COMMA if i != 0
           collector = visit arg, collector
         }
         collector << ')'
@@ -174,7 +174,7 @@ module ArelExtensions
       def visit_ArelExtensions_Nodes_Power(o, collector)
         collector << 'POWER('
         o.expressions.each_with_index { |arg, i|
-          collector << Arel::Visitors::ToSql::COMMA if i != 0
+          collector << LOADED_VISITOR::COMMA if i != 0
           collector = visit arg, collector
         }
         collector << ')'
@@ -208,7 +208,7 @@ module ArelExtensions
       def visit_ArelExtensions_Nodes_Repeat(o, collector)
         collector << 'REPLICATE('
         o.expressions.each_with_index { |arg, i|
-          collector << Arel::Visitors::ToSql::COMMA if i != 0
+          collector << LOADED_VISITOR::COMMA if i != 0
           collector = visit arg, collector
         }
         collector << ')'
@@ -344,7 +344,7 @@ module ArelExtensions
         if o.right && !/\A\s\Z/.match(o.right.expr)
           collector << 'dbo.TrimChar('
           collector = visit o.left, collector
-          collector << Arel::Visitors::MSSQL::COMMA
+          collector << LOADED_VISITOR::COMMA
           collector = visit o.right, collector
           collector << ')'
         else
@@ -762,7 +762,7 @@ module ArelExtensions
       def visit_ArelExtensions_Nodes_LevenshteinDistance(o, collector)
         collector << 'dbo.LEVENSHTEIN_DISTANCE('
         collector = visit o.left, collector
-        collector << Arel::Visitors::ToSql::COMMA
+        collector << LOADED_VISITOR::COMMA
         collector = visit o.right, collector
         collector << ')'
         collector
@@ -771,7 +771,7 @@ module ArelExtensions
       def visit_ArelExtensions_Nodes_JsonGet(o, collector)
         collector << 'JSON_VALUE('
         collector = visit o.dict, collector
-        collector << Arel::Visitors::MySQL::COMMA
+        collector << LOADED_VISITOR::COMMA
         if o.key.is_a?(Integer)
           collector << "\"$[#{o.key}]\""
         else

--- a/lib/arel_extensions/visitors/mssql.rb
+++ b/lib/arel_extensions/visitors/mssql.rb
@@ -647,7 +647,7 @@ module ArelExtensions
       end
 
       def visit_ArelExtensions_Nodes_MD5(o, collector)
-        collector << "LOWER(CONVERT(NVARCHAR(32),HashBytes('MD5',CONVERT(VARCHAR,"
+        collector << "LOWER(CONVERT(NVARCHAR(32),HashBytes('MD5',CONVERT(VARCHAR(MAX),"
         collector = visit o.left, collector
         collector << ')),2))'
         collector
@@ -657,7 +657,7 @@ module ArelExtensions
         as_attr =
           case o.as_attr
           when :string
-            'varchar'
+            'varchar(MAX)'
           when :time
             'time'
           when :date

--- a/lib/arel_extensions/visitors/mssql.rb
+++ b/lib/arel_extensions/visitors/mssql.rb
@@ -625,7 +625,7 @@ module ArelExtensions
       def visit_ArelExtensions_Nodes_GroupConcat(o, collector)
         collector << '(STRING_AGG('
         collector = visit o.left, collector
-        collector << Arel::Visitors::Oracle::COMMA
+        collector << LOADED_VISITOR::COMMA
         sep = o.separator.is_a?(Arel::Nodes::Quoted) ? o.separator.expr : o.separator
         collector =
           if 'NULL' == sep
@@ -636,7 +636,7 @@ module ArelExtensions
         collector << ') WITHIN GROUP (ORDER BY '
         if o.order.present?
           o.order.each_with_index do |order, i|
-            collector << Arel::Visitors::Oracle::COMMA if i != 0
+            collector << LOADED_VISITOR::COMMA if i != 0
             collector = visit order, collector
           end
         else

--- a/lib/arel_extensions/visitors/mysql.rb
+++ b/lib/arel_extensions/visitors/mysql.rb
@@ -68,7 +68,7 @@ module ArelExtensions
       def visit_ArelExtensions_Nodes_Log10(o, collector)
         collector << 'LOG10('
         o.expressions.each_with_index { |arg, i|
-          collector << Arel::Visitors::ToSql::COMMA if i != 0
+          collector << COMMA if i != 0
           collector = visit arg, collector
         }
         collector << ')'
@@ -78,7 +78,7 @@ module ArelExtensions
       def visit_ArelExtensions_Nodes_Power(o, collector)
         collector << 'POW('
         o.expressions.each_with_index { |arg, i|
-          collector << Arel::Visitors::ToSql::COMMA if i != 0
+          collector << COMMA if i != 0
           collector = visit arg, collector
         }
         collector << ')'
@@ -212,7 +212,7 @@ module ArelExtensions
         if !o.order.blank?
           collector << ' ORDER BY '
           o.order.each_with_index do |order, i|
-            collector << Arel::Visitors::ToSql::COMMA if i != 0
+            collector << COMMA if i != 0
             collector = visit order, collector
           end
         end
@@ -255,7 +255,7 @@ module ArelExtensions
       def visit_ArelExtensions_Nodes_Repeat(o, collector)
         collector << 'REPEAT('
         o.expressions.each_with_index { |arg, i|
-          collector << Arel::Visitors::ToSql::COMMA if i != 0
+          collector << COMMA if i != 0
           collector = visit arg, collector
         }
         collector << ')'
@@ -291,9 +291,9 @@ module ArelExtensions
         when :integer, :float, :decimal
           collector << 'FORMAT('
           collector = visit o.left, collector
-          collector << Arel::Visitors::ToSql::COMMA
+          collector << COMMA
           collector << '2'
-          collector << Arel::Visitors::ToSql::COMMA
+          collector << COMMA
           collector = visit o.right, collector
           collector << ')'
         else

--- a/lib/arel_extensions/visitors/mysql.rb
+++ b/lib/arel_extensions/visitors/mysql.rb
@@ -588,7 +588,7 @@ module ArelExtensions
             if i != 0
               collector << COMMA
             end
-            collector = visit v, collector
+            collector = visit_json_value(o, v, collector)
           end
           collector << ')'
         when Hash
@@ -599,11 +599,29 @@ module ArelExtensions
             end
             collector = visit k, collector
             collector << COMMA
-            collector = visit v, collector
+            collector = visit_json_value(o, v, collector)
           end
           collector << ')'
         else
-          collector = visit o.dict, collector
+          collector = visit_json_value(o, o.dict, collector)
+        end
+        collector
+      end
+
+      # A JSON Boolean must render as `true`/`false`, not the integer `1`/`0` that MySQL
+      # collapses `TRUE`/`FALSE` into inside JSON functions (MariaDB keeps them boolean).
+      def visit_json_value(o, v, collector)
+        if o.boolean_literal?(v)
+          value = v.is_a?(Arel::Nodes::Quoted) ? v.expr : v
+          collector << "JSON_EXTRACT('#{value}', '$')"
+        elsif o.type_of_node(v) == :boolean
+          collector << 'JSON_EXTRACT(CASE WHEN '
+          collector = visit v, collector
+          collector << " IS NULL THEN NULL WHEN "
+          collector = visit v, collector
+          collector << " THEN 'true' ELSE 'false' END, '$')"
+        else
+          collector = visit v, collector
         end
         collector
       end

--- a/lib/arel_extensions/visitors/oracle.rb
+++ b/lib/arel_extensions/visitors/oracle.rb
@@ -30,7 +30,7 @@ module ArelExtensions
       def visit_ArelExtensions_Nodes_Log10(o, collector)
         collector << 'LOG('
         o.expressions.each_with_index { |arg, i|
-          collector << Arel::Visitors::ToSql::COMMA if i != 0
+          collector << COMMA if i != 0
           collector = visit arg, collector
         }
         collector << ',10)'
@@ -40,7 +40,7 @@ module ArelExtensions
       def visit_ArelExtensions_Nodes_Power(o, collector)
         collector << 'POWER('
         o.expressions.each_with_index { |arg, i|
-          collector << Arel::Visitors::ToSql::COMMA if i != 0
+          collector << COMMA if i != 0
           collector = visit arg, collector
         }
         collector << ')'
@@ -495,9 +495,9 @@ module ArelExtensions
       def visit_ArelExtensions_Nodes_Repeat(o, collector)
         collector << 'LPAD('
         collector = visit o.expressions[0], collector # can't put empty string, otherwise it wouldn't work
-        collector << Arel::Visitors::ToSql::COMMA
+        collector << COMMA
         collector = visit o.expressions[1], collector
-        collector << Arel::Visitors::ToSql::COMMA
+        collector << COMMA
         collector = visit o.expressions[0], collector
         collector << ')'
         collector
@@ -718,7 +718,7 @@ module ArelExtensions
       def visit_ArelExtensions_Nodes_LevenshteinDistance(o, collector)
         collector << 'UTL_MATCH.edit_distance('
         collector = visit o.left, collector
-        collector << Arel::Visitors::ToSql::COMMA
+        collector << COMMA
         collector = visit o.right, collector
         collector << ')'
         collector

--- a/lib/arel_extensions/visitors/oracle12.rb
+++ b/lib/arel_extensions/visitors/oracle12.rb
@@ -53,7 +53,7 @@ module ArelExtensions
           collector << 'json_array('
           o.dict.each.with_index do |v, i|
             if i != 0
-              collector << Arel::Visitors::MySQL::COMMA
+              collector << COMMA
             end
             collector = visit v, collector
           end
@@ -62,7 +62,7 @@ module ArelExtensions
           collector << 'json__object('
           o.dict.each.with_index do |(k, v), i|
             if i != 0
-              collector << Arel::Visitors::MySQL::COMMA
+              collector << COMMA
             end
             collector << 'KEY '
             collector = visit k, collector

--- a/lib/arel_extensions/visitors/postgresql.rb
+++ b/lib/arel_extensions/visitors/postgresql.rb
@@ -48,7 +48,7 @@ module ArelExtensions
       def visit_ArelExtensions_Nodes_Power(o, collector)
         collector << 'POWER('
         o.expressions.each_with_index { |arg, i|
-          collector << Arel::Visitors::ToSql::COMMA if i != 0
+          collector << COMMA if i != 0
           collector = visit arg, collector
         }
         collector << ')'
@@ -58,7 +58,7 @@ module ArelExtensions
       def visit_ArelExtensions_Nodes_Log10(o, collector)
         collector << 'LOG('
         o.expressions.each_with_index { |arg, i|
-          collector << Arel::Visitors::ToSql::COMMA if i != 0
+          collector << COMMA if i != 0
           collector = visit arg, collector
         }
         collector << ')'
@@ -214,7 +214,7 @@ module ArelExtensions
       def visit_ArelExtensions_Nodes_Repeat(o, collector)
         collector << 'REPEAT('
         o.expressions.each_with_index { |arg, i|
-          collector << Arel::Visitors::ToSql::COMMA if i != 0
+          collector << COMMA if i != 0
           collector = visit arg, collector
         }
         collector << ')'
@@ -347,14 +347,14 @@ module ArelExtensions
       def visit_ArelExtensions_Nodes_RegexpReplace(o, collector)
         collector << 'REGEXP_REPLACE('
         visit o.left, collector
-        collector << Arel::Visitors::ToSql::COMMA
+        collector << COMMA
         tab = o.pattern.inspect + 'g' # Make it always global
         pattern = tab.split('/')[1..-2].join('/')
         flags = tab.split('/')[-1]
         visit Arel.quoted(pattern), collector
-        collector << Arel::Visitors::ToSql::COMMA
+        collector << COMMA
         visit o.substitute, collector
-        collector << Arel::Visitors::ToSql::COMMA
+        collector << COMMA
         visit Arel.quoted(flags + 'g'), collector
         collector << ')'
         collector
@@ -537,7 +537,7 @@ module ArelExtensions
             collector << 'to_jsonb(array['
             o.dict.each.with_index do |v, i|
               if i != 0
-                collector << Arel::Visitors::MySQL::COMMA
+                collector << COMMA
               end
               collector = visit v, collector
             end
@@ -547,10 +547,10 @@ module ArelExtensions
           collector << 'jsonb_build_object('
           o.dict.each.with_index do |(k, v), i|
             if i != 0
-              collector << Arel::Visitors::MySQL::COMMA
+              collector << COMMA
             end
             collector = visit k, collector
-            collector << Arel::Visitors::MySQL::COMMA
+            collector << COMMA
             collector = visit v, collector
           end
           collector << ')'
@@ -594,15 +594,15 @@ module ArelExtensions
       def visit_ArelExtensions_Nodes_JsonSet(o, collector)
         collector << 'jsonb_set('
         collector = visit o.dict, collector
-        collector << Arel::Visitors::MySQL::COMMA
+        collector << COMMA
         collector << 'array['
         collector = visit o.key, collector
         collector << ']'
-        collector << Arel::Visitors::MySQL::COMMA
+        collector << COMMA
         collector << 'COALESCE('
         collector = visit o.value, collector
         collector << ", 'null'::jsonb)"
-        collector << Arel::Visitors::MySQL::COMMA
+        collector << COMMA
         collector << 'true)'
         collector
       end
@@ -621,7 +621,7 @@ module ArelExtensions
               end
               collector << 'jsonb_object_agg('
               collector = visit k, collector
-              collector << Arel::Visitors::MySQL::COMMA
+              collector << COMMA
               collector = visit v, collector
               collector << ')'
             end

--- a/lib/arel_extensions/visitors/postgresql.rb
+++ b/lib/arel_extensions/visitors/postgresql.rb
@@ -554,8 +554,17 @@ module ArelExtensions
         when NilClass
           collector << %('null'::jsonb)
         else
-          collector = visit o.dict, collector
-          collector << '::jsonb'
+          if o.dict.is_a?(Arel::Nodes::Quoted) && o.dict.expr.nil?
+            # `Arel.null` must mean the JSON null member, not SQL NULL:
+            # `to_jsonb(NULL)` would raise a polymorphic-type error.
+            collector << %('null'::jsonb)
+          else
+            # `to_jsonb` rather than `::jsonb` so a non-JSON value (e.g. a text column) is
+            # encoded as a JSON string instead of rejected by the server.
+            collector << 'to_jsonb('
+            collector = visit o.dict, collector
+            collector << ')'
+          end
         end
         collector
       end
@@ -584,7 +593,9 @@ module ArelExtensions
         collector = visit o.key, collector
         collector << ']'
         collector << Arel::Visitors::MySQL::COMMA
+        collector << 'COALESCE('
         collector = visit o.value, collector
+        collector << ", 'null'::jsonb)"
         collector << Arel::Visitors::MySQL::COMMA
         collector << 'true)'
         collector

--- a/lib/arel_extensions/visitors/postgresql.rb
+++ b/lib/arel_extensions/visitors/postgresql.rb
@@ -529,14 +529,20 @@ module ArelExtensions
       def visit_ArelExtensions_Nodes_Json(o, collector)
         case o.dict
         when Array
-          collector << 'to_jsonb(array['
-          o.dict.each.with_index do |v, i|
-            if i != 0
-              collector << Arel::Visitors::MySQL::COMMA
+          if o.dict.empty?
+            # `to_jsonb(array[])` would raise "cannot determine type of empty array";
+            # an empty array is simply the `[]` JSON literal.
+            collector << %('[]'::jsonb)
+          else
+            collector << 'to_jsonb(array['
+            o.dict.each.with_index do |v, i|
+              if i != 0
+                collector << Arel::Visitors::MySQL::COMMA
+              end
+              collector = visit v, collector
             end
-            collector = visit v, collector
+            collector << '])'
           end
-          collector << '])'
         when Hash
           collector << 'jsonb_build_object('
           o.dict.each.with_index do |(k, v), i|

--- a/lib/arel_extensions/visitors/to_sql.rb
+++ b/lib/arel_extensions/visitors/to_sql.rb
@@ -626,6 +626,15 @@ module ArelExtensions
           # A bare numeric literal (e.g. `{ col => 1 }`) is never NULL, so it is
           # emitted as-is rather than run through `is_null`/`coalesce`.
           Arel.quoted(v)
+        when :boolean
+          # A literal boolean is never NULL: emit the JSON token directly.
+          # A boolean column is null-checked and rendered as true/false. `eq(true)` rather than the
+          # bare column, because T-SQL (mssql) requires a proper boolean predicate in WHEN.
+          if o.boolean_literal?(v)
+            Arel.quoted((v.is_a?(Arel::Nodes::Quoted) ? v.expr : v).to_s)
+          else
+            Arel.when(v.is_null).then(make_json_null).else(Arel.when(v.eq(true)).then('true').else('false'))
+          end
         when :string
           Arel.when(v.is_null).then(make_json_null).else(make_json_string(v))
         when :date
@@ -668,7 +677,7 @@ module ArelExtensions
           res += '}'
           collector = visit res, collector
         else
-          collector = visit o.dict, collector
+          collector = visit(o.boolean_literal?(o.dict) ? Arel.quoted(o.dict.expr.to_s) : o.dict, collector)
         end
         collector
       end

--- a/lib/arel_extensions/visitors/to_sql.rb
+++ b/lib/arel_extensions/visitors/to_sql.rb
@@ -622,6 +622,10 @@ module ArelExtensions
 
       def json_value(o, v)
         case o.type_of_node(v)
+        when :numeric
+          # A bare numeric literal (e.g. `{ col => 1 }`) is never NULL, so it is
+          # emitted as-is rather than run through `is_null`/`coalesce`.
+          Arel.quoted(v)
         when :string
           Arel.when(v.is_null).then(make_json_null).else(make_json_string(v))
         when :date

--- a/test/with_ar/all_agnostic_test.rb
+++ b/test/with_ar/all_agnostic_test.rb
@@ -1201,6 +1201,37 @@ module ArelExtensions
         assert_equal ({'Arthur' => 'ArthurArthur', 'Arthur2' => 1}), parse_json(t(@arthur, h1.merge({})))
       end
 
+      def test_json_scalar_values
+        assert_equal 42, parse_json(t(@arthur, Arel.json(42)))
+        assert_equal({}, parse_json(t(@arthur, Arel.json({}))))
+        assert_nil t(@arthur, Arel.json(nil))
+
+        skip 'Known failure: postgres to_jsonb(array[]) cannot determine type of empty array' if @env_db == 'postgresql'
+        assert_equal [], parse_json(t(@arthur, Arel.json([])))
+
+        skip 'Known failure: booleans crash at construction (convert_to_node rejects TrueClass/FalseClass)'
+        assert_equal true, parse_json(t(@arthur, Arel.json(true)))
+        assert_equal ({'Arthur' => false}), parse_json(t(@arthur, Arel.json({@name => false})))
+      end
+
+      def test_json_special_chars
+        assert_equal ({'Arthur' => 'say "hi"'}), parse_json(t(@arthur, Arel.json({@name => 'say "hi"'})))
+        assert_equal ({'Arthur' => 'a\\b'}), parse_json(t(@arthur, Arel.json({@name => 'a\\b'})))
+        assert_equal ({'Arthur' => "line1\nline2"}), parse_json(t(@arthur, Arel.json({@name => "line1\nline2"})))
+        assert_equal ({'we"ird' => 'Arthur'}), parse_json(t(@arthur, Arel.json({'we"ird' => @name})))
+      end
+
+      def test_json_date_values
+        assert_equal ({'Arthur' => '2016-05-23'}), parse_json(t(@arthur, Arel.json({@name => @created_at})))
+        res = parse_json(t(@laure, Arel.json({@name => @duration})))['Laure']
+        assert_equal '12:42:21', res.sub(/\.\d+\z/, '') # MySQL (unlinke MariaDB) adds `.\d+` to a datetime column inside a json.
+
+        # the generic builder's `:datetime` branch is only used by sqlite and mssql.
+        if $sqlite || @env_db == 'mssql'
+          assert_equal ({'Lucas' => '2014-03-03T12:42:00'}), parse_json(t(@lucas, Arel.json({@name => @updated_at})))
+        end
+      end
+
       def test_as_on_everything
         name = @arthur.select(@name.as('NaMe')).first.attributes
         assert_equal 'Arthur', name['NaMe'] || name['name'] # because of Oracle

--- a/test/with_ar/all_agnostic_test.rb
+++ b/test/with_ar/all_agnostic_test.rb
@@ -1145,15 +1145,19 @@ module ArelExtensions
         assert_equal 1,  t(@arthur, @name.levenshtein_distance('Artehur'))
       end
 
-      def test_json
-        skip "Can't be tested on travis"
+      def test_json_create
+        skip 'Known failure: PG::InvalidTextRepresentation (`::jsonb` cast of non-JSON text)' if @env_db == 'postgresql'
+        skip 'Known failure: ToSQL json_value NoMethodError on Integer (is_null)' if $sqlite || @env_db == 'mssql'
         # creation
         assert_equal 'Arthur', t(@arthur, Arel.json(@name))
         assert_equal %w[Arthur Arthur], parse_json(t(@arthur, Arel.json(@name, @name)))
         assert_equal ({'Arthur' => 'Arthur', 'Arthur2' => 'ArthurArthur'}), parse_json(t(@arthur, Arel.json({@name => @name, @name + '2' => @name + @name})))
         assert_equal ({'Arthur' => 'Arthur', 'Arthur2' => 1}), parse_json(t(@arthur, Arel.json({@name => @name, @name + '2' => 1})))
         assert_equal [{'age' => 21}, {'name' => 'Arthur', 'score' => 65.62}], parse_json(t(@arthur, Arel.json([{age: @age}, {name: @name, score: @score}])))
+      end
 
+      def test_json_aggregate
+        skip 'Known failure: NameError Arel::Visitors::Oracle in mssql GroupConcat' if @env_db == 'mssql'
         # aggregate
         assert_equal ({'5' => 'Lucas', '15' => 'Sophie', '23' => 'Myung', '25' => 'Laure'}),
                      parse_json(t(User.group(:score).where(@age.is_not_null).where(@score == 20.16), Arel.json({@age => @name}).group(false)))
@@ -1164,7 +1168,10 @@ module ArelExtensions
 
         # puts User.group(:score).where(@age.is_not_null).where(@score == 20.16).select(@score, Arel.json({@age => @name}).group(true,[@age])).to_sql
         # puts User.group(:score).where(@age.is_not_null).where(@score == 20.16).select(@score, Arel.json({@age => @name}).group(true,[@age])).to_a
+      end
 
+      def test_json_get
+        skip 'Known failure: postgres ->> returns text, not parsed JSON' if @env_db == 'postgresql'
         skip 'Not Yet Implemented' if $sqlite || %w[oracle mssql].include?(@env_db)
         # get
         h1 = Arel.json({@name => @name + @name, @name + '2' => 1})
@@ -1173,12 +1180,23 @@ module ArelExtensions
         assert_equal ({'age' => 21}), parse_json(t(@arthur, h2.get(0)))
         assert_equal 21, parse_json(t(@arthur, h2.get(0).get('age')))
         assert_nil t(@arthur, h2.get('age'))
+      end
+
+      def test_json_set
+        skip 'Known failure: postgres jsonb_set(NULL value) returns NULL' if @env_db == 'postgresql'
+        skip 'Not Yet Implemented' if $sqlite || %w[oracle mssql].include?(@env_db)
         # set
+        h1 = Arel.json({@name => @name + @name, @name + '2' => 1})
         assert_equal ({'Arthur' => %w[toto tata], 'Arthur2' => 1}), parse_json(t(@arthur, h1.set(@name, %w[toto tata])))
         assert_equal ({'Arthur' => 'ArthurArthur', 'Arthur2' => 1, 'Arthur3' => 2}), parse_json(t(@arthur, h1.set(@name + '3', 2)))
         assert_equal ({'Arthur' => 'ArthurArthur', 'Arthur2' => 1, 'Arthur3' => nil}), parse_json(t(@arthur, h1.set(@name + '3', nil)))
         assert_equal ({'Arthur' => 'ArthurArthur', 'Arthur2' => 1, 'Arthur3' => {'a' => 2}}), parse_json(t(@arthur, h1.set(@name + '3', {a: 2})))
+      end
+
+      def test_json_merge
+        skip 'Not Yet Implemented' if $sqlite || %w[oracle mssql].include?(@env_db)
         # merge
+        h1 = Arel.json({@name => @name + @name, @name + '2' => 1})
         assert_equal ({'Arthur' => %w[toto tata], 'Arthur2' => 1, 'Arthur3' => 2}), parse_json(t(@arthur, h1.merge({@name => %w[toto tata]}, {@name + '3' => 2})))
         assert_equal ({'Arthur' => %w[toto tata], 'Arthur2' => 1, 'Arthur3' => 2}), parse_json(t(@arthur, h1.merge({@name => %w[toto tata], @name + '3' => 2})))
         assert_equal ({'Arthur' => 'ArthurArthur', 'Arthur2' => 1}), parse_json(t(@arthur, h1.merge({})))

--- a/test/with_ar/all_agnostic_test.rb
+++ b/test/with_ar/all_agnostic_test.rb
@@ -299,6 +299,7 @@ module ArelExtensions
         skip "Sqlite can't do md5" if $sqlite
         assert_equal 'e2cf99ca82a7e829d2a4ac85c48154d0', t(@camille, @name.md5)
         assert_equal 'c3d41bf5efb468a1bcce53bd53726c85', t(@lucas, @name.md5)
+        assert_equal '6eb6a030bcce166534b95bc2ab45d9cf', t(@lucas, Arel.quoted('a' * 50).md5)
       end
 
       def test_locate
@@ -823,6 +824,7 @@ module ArelExtensions
       # TODO; cast types
       def test_cast_types
         assert_equal '5', t(@lucas, @age.cast(:string))
+        assert_equal 'a' * 50, t(@lucas, Arel.quoted('a' * 50).cast(:string))
         skip 'jdbc adapters does not work properly here (v52 works fine)' if RUBY_PLATFORM.match?(/java/i)
         if @env_db == 'mysql' || @env_db == 'postgresql' || @env_db == 'oracle' || @env_db == 'mssql'
           assert_equal 1, t(@laure, Arel.when(@duration.cast(:time).cast(:string).eq('12:42:21')).then(1).else(0)) unless @env_db == 'oracle' || @env_db == 'mssql'
@@ -1153,7 +1155,6 @@ module ArelExtensions
         assert_equal %w[Arthur Arthur], parse_json(t(@arthur, Arel.json(@name, @name)))
         assert_equal ({'Arthur' => 'Arthur', 'Arthur2' => 'ArthurArthur'}), parse_json(t(@arthur, Arel.json({@name => @name, @name + '2' => @name + @name})))
         assert_equal ({'Arthur' => 'Arthur', 'Arthur2' => 1}), parse_json(t(@arthur, Arel.json({@name => @name, @name + '2' => 1})))
-        skip 'Known failure: mssql varchar(30) (the default when `varchar` has no explicit size) truncates nested JSON objects' if @env_db == 'mssql'
         assert_equal [{'age' => 21}, {'name' => 'Arthur', 'score' => 65.62}], parse_json(t(@arthur, Arel.json([{age: @age}, {name: @name, score: @score}])))
       end
 

--- a/test/with_ar/all_agnostic_test.rb
+++ b/test/with_ar/all_agnostic_test.rb
@@ -1149,7 +1149,6 @@ module ArelExtensions
       end
 
       def test_json_create
-        skip 'Known failure: PG::InvalidTextRepresentation (`::jsonb` cast of non-JSON text)' if @env_db == 'postgresql'
         # creation
         assert_equal 'Arthur', t(@arthur, Arel.json(@name))
         assert_equal %w[Arthur Arthur], parse_json(t(@arthur, Arel.json(@name, @name)))
@@ -1184,7 +1183,6 @@ module ArelExtensions
       end
 
       def test_json_set
-        skip 'Known failure: postgres jsonb_set(NULL value) returns NULL' if @env_db == 'postgresql'
         skip 'Not Yet Implemented' if $sqlite || %w[oracle mssql].include?(@env_db)
         # set
         h1 = Arel.json({@name => @name + @name, @name + '2' => 1})

--- a/test/with_ar/all_agnostic_test.rb
+++ b/test/with_ar/all_agnostic_test.rb
@@ -1148,12 +1148,12 @@ module ArelExtensions
 
       def test_json_create
         skip 'Known failure: PG::InvalidTextRepresentation (`::jsonb` cast of non-JSON text)' if @env_db == 'postgresql'
-        skip 'Known failure: ToSQL json_value NoMethodError on Integer (is_null)' if $sqlite || @env_db == 'mssql'
         # creation
         assert_equal 'Arthur', t(@arthur, Arel.json(@name))
         assert_equal %w[Arthur Arthur], parse_json(t(@arthur, Arel.json(@name, @name)))
         assert_equal ({'Arthur' => 'Arthur', 'Arthur2' => 'ArthurArthur'}), parse_json(t(@arthur, Arel.json({@name => @name, @name + '2' => @name + @name})))
         assert_equal ({'Arthur' => 'Arthur', 'Arthur2' => 1}), parse_json(t(@arthur, Arel.json({@name => @name, @name + '2' => 1})))
+        skip 'Known failure: mssql varchar(30) (the default when `varchar` has no explicit size) truncates nested JSON objects' if @env_db == 'mssql'
         assert_equal [{'age' => 21}, {'name' => 'Arthur', 'score' => 65.62}], parse_json(t(@arthur, Arel.json([{age: @age}, {name: @name, score: @score}])))
       end
 

--- a/test/with_ar/all_agnostic_test.rb
+++ b/test/with_ar/all_agnostic_test.rb
@@ -52,6 +52,7 @@ module ArelExtensions
           t.column :duration, :time
           t.column :other, :string
           t.column :score, :decimal, precision: 20, scale: 10
+          t.column :enabled, :boolean
         end
         @cnx.drop_table(:product_tests) rescue nil
         @cnx.create_table :product_tests do |t|
@@ -74,9 +75,9 @@ module ArelExtensions
         @lucas = User.where(id: u.id)
         u = User.create age: 15, name: 'Sophie', created_at: d, score: 20.16
         @sophie = User.where(id: u.id)
-        u = User.create age: 20, name: 'Camille', created_at: d, score: -20.16, comments: ''
+        u = User.create age: 20, name: 'Camille', created_at: d, score: -20.16, comments: '', enabled: false
         @camille = User.where(id: u.id)
-        u = User.create age: 21, name: 'Arthur', created_at: d, score: 65.62, comments: 'arrêté'
+        u = User.create age: 21, name: 'Arthur', created_at: d, score: 65.62, comments: 'arrêté', enabled: true
         @arthur = User.where(id: u.id)
         u = User.create age: 23, name: 'Myung', created_at: d, score: 20.16, comments: ' '
         @myung = User.where(id: u.id)
@@ -107,6 +108,7 @@ module ArelExtensions
         @duration = User.arel_table[:duration]
         @price = Product.arel_table[:price]
         @other = User.arel_table[:other]
+        @enabled = User.arel_table[:enabled]
         @not_in_table = User.arel_table[:not_in_table]
 
         @ut = User.arel_table
@@ -1208,9 +1210,12 @@ module ArelExtensions
         assert_equal({}, parse_json(t(@arthur, Arel.json({}))))
         assert_equal [], parse_json(t(@arthur, Arel.json([])))
 
-        skip 'Known failure: booleans crash at construction (convert_to_node rejects TrueClass/FalseClass)'
         assert_equal true, parse_json(t(@arthur, Arel.json(true)))
         assert_equal ({'Arthur' => false}), parse_json(t(@arthur, Arel.json({@name => false})))
+
+        assert_equal ({'Arthur' => true}), parse_json(t(@arthur, Arel.json({@name => @enabled})))
+        assert_equal ({'Camille' => false}), parse_json(t(@camille, Arel.json({@name => @enabled})))
+        assert_equal ({'Lucas' => nil}), parse_json(t(@lucas, Arel.json({@name => @enabled})))
       end
 
       def test_json_special_chars

--- a/test/with_ar/all_agnostic_test.rb
+++ b/test/with_ar/all_agnostic_test.rb
@@ -1202,11 +1202,10 @@ module ArelExtensions
       end
 
       def test_json_scalar_values
-        assert_equal 42, parse_json(t(@arthur, Arel.json(42)))
-        assert_equal({}, parse_json(t(@arthur, Arel.json({}))))
         assert_nil t(@arthur, Arel.json(nil))
 
-        skip 'Known failure: postgres to_jsonb(array[]) cannot determine type of empty array' if @env_db == 'postgresql'
+        assert_equal 42, parse_json(t(@arthur, Arel.json(42)))
+        assert_equal({}, parse_json(t(@arthur, Arel.json({}))))
         assert_equal [], parse_json(t(@arthur, Arel.json([])))
 
         skip 'Known failure: booleans crash at construction (convert_to_node rejects TrueClass/FalseClass)'

--- a/test/with_ar/all_agnostic_test.rb
+++ b/test/with_ar/all_agnostic_test.rb
@@ -260,8 +260,9 @@ module ArelExtensions
         assert_equal 'Camille Camille', t(@camille, @name + ' ' + @name)
         assert_equal 'Laure 2', t(@laure, @name + ' ' + 2)
         assert_equal 'Test Laure', t(@laure, Arel.quoted('Test ') + @name)
+      end
 
-        skip 'No group_concat in SqlServer before 2017' if @env_db == 'mssql'
+      def test_group_concat
         assert_equal 'Lucas Sophie', t(User.where(name: %w[Lucas Sophie]), @name.group_concat(' '))
         assert_equal 'Lucas,Sophie', t(User.where(name: %w[Lucas Sophie]), @name.group_concat(','))
         assert_equal 'Lucas,Sophie', t(User.where(name: %w[Lucas Sophie]), @name.group_concat)
@@ -1157,7 +1158,6 @@ module ArelExtensions
       end
 
       def test_json_aggregate
-        skip 'Known failure: NameError Arel::Visitors::Oracle in mssql GroupConcat' if @env_db == 'mssql'
         # aggregate
         assert_equal ({'5' => 'Lucas', '15' => 'Sophie', '23' => 'Myung', '25' => 'Laure'}),
                      parse_json(t(User.group(:score).where(@age.is_not_null).where(@score == 20.16), Arel.json({@age => @name}).group(false)))


### PR DESCRIPTION
This PR does 2 things:

1. Fixes various issues with JSON in all databases: (numerics, bools, nil, etc)
2. Enables and expands the tests of JSON in the test suite.

It's provoked by a community request to improve JSON implementation:

1. https://github.com/Faveod/arel-extensions/pull/140
2. https://github.com/Faveod/arel-extensions/pull/141

Once merged, the aforementioned PRs could be rebased and improved.
