### PR TITLE
Reflect a column against the database that owns its table

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 ## [unreleased]
 
+- An attribute from the `arel_table` of a model now gets its type from its type caster. The
+  type caster knows that type. Before, `coalesce` and `case` asked the database for it.
+
 ## Release v2.5.0/v1.7.0 (02-09-2026)
 
 - Fix a typo preventing optimizer hints from being applied on SELECT in MySQL.

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 - An attribute from the `arel_table` of a model now gets its type from its type caster. The
   type caster knows that type. Before, `coalesce` and `case` asked the database for it.
+- `column_of` now reflects a table on the database that owns that table. Before, it always
+  used the connection of `ActiveRecord::Base`. If a model connected to a different database,
+  that reflection failed. The failure was silent, thus the function lost its type. On postgres,
+  the failed statement also stopped the transaction.
 
 ## Release v2.5.0/v1.7.0 (02-09-2026)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,10 @@
   used the connection of `ActiveRecord::Base`. If a model connected to a different database,
   that reflection failed. The failure was silent, thus the function lost its type. On postgres,
   the failed statement also stopped the transaction.
+- `column_of` no longer reflects a name that no model declares, if the database has no data
+  for that name. `Arel::Table.new` also makes the name of a common table expression. A
+  reflection on such a name can only fail. The schema cache keeps the list of data sources,
+  thus `column_of` examines that list first.
 
 ## Release v2.5.0/v1.7.0 (02-09-2026)
 

--- a/lib/arel_extensions/helpers.rb
+++ b/lib/arel_extensions/helpers.rb
@@ -26,6 +26,26 @@ module ArelExtensions
     nil
   end
 
+  # The type of the column that `att` points to.
+  #
+  # A model makes the attributes of its `arel_table` with a type caster. The
+  # type caster knows the type of the column. A query to the database is not
+  # necessary. If the model connects to a different database, the query also
+  # gets the wrong answer.
+  #
+  # A bare `Arel::Table` has no type caster. A common table expression has no
+  # type caster. For these two, only the name of the table is available. The
+  # method must ask the database.
+  def self.type_of(att)
+    if att.respond_to?(:type_caster) && att.able_to_type_cast?
+      att.type_caster&.type
+    elsif att.respond_to?(:relation)
+      column_of(att.relation.table_name, att.name.to_s)&.type
+    end
+  rescue ActiveRecord::ConnectionNotEstablished, ActiveRecord::StatementInvalid
+    nil
+  end
+
   def self.column_of(table_name, column_name)
     pool = ActiveRecord::Base.connection.pool
     use_arel_table = !ActiveRecord::Base.connected? \

--- a/lib/arel_extensions/helpers.rb
+++ b/lib/arel_extensions/helpers.rb
@@ -26,49 +26,81 @@ module ArelExtensions
     nil
   end
 
-  # The type of the column that `att` points to.
+  # The object that knows the type of the attribute +att+.
   #
-  # A model makes the attributes of its `arel_table` with a type caster. The
-  # type caster knows the type of the column. A query to the database is not
-  # necessary. If the model connects to a different database, the query also
-  # gets the wrong answer.
+  # An attribute from the +arel_table+ of a model has a type caster. Return it.
   #
-  # A bare `Arel::Table` has no type caster. A common table expression has no
-  # type caster. For these two, only the name of the table is available. The
-  # method must ask the database.
-  def self.type_of(att)
-    if att.respond_to?(:type_caster) && att.able_to_type_cast?
-      att.type_caster&.type
+  # A bare +Arel::Table+ or a common table expression has no type caster. We
+  # only have the table name, so look up the column in the database.
+  #
+  # @param att [Arel::Attributes::Attribute] the attribute to describe.
+  # @return [ActiveModel::Type::Value, ActiveRecord::ConnectionAdapters::Column, nil]
+  #   a type caster or a column. Both respond to +type+. nil if neither is
+  #   available.
+  def self.type_source_of(att)
+    if att.is_a?(Arel::Attribute) && att.respond_to?(:able_to_type_cast?) && att.able_to_type_cast?
+      if att.respond_to?(:type_caster) # activerecord >= 6.1
+        att.type_caster
+      else
+        # activerecord <= 6.0 keeps the type caster of an `Arel::Table` out of
+        # reach, so ask the model that declares the table.
+        model_of(att.relation.table_name)&.type_for_attribute(att.name.to_s)
+      end
     elsif att.respond_to?(:relation)
-      column_of(att.relation.table_name, att.name.to_s)&.type
+      column_of(att.relation.table_name, att.name.to_s)
     end
   rescue ActiveRecord::ConnectionNotEstablished, ActiveRecord::StatementInvalid
     nil
   end
 
-  # The model that declares `table_name`, if the application loaded that model.
+  # The type of the column that +att+ points to.
   #
-  # `column_of` gets only the name of a table. That table can be in a different
-  # database than the database of `ActiveRecord::Base`. If an application has
-  # more than one database, the model that declares the table knows the correct
-  # pool.
-  def self.model_of(table_name)
-    return nil unless defined?(ActiveRecord::Base) && ActiveRecord::Base.respond_to?(:descendants)
+  # @param att [Arel::Attributes::Attribute] the attribute to type.
+  # @return [Symbol, nil] the type of the column, or nil if unknown.
+  def self.type_of(att)
+    type_source_of(att)&.type
+  end
 
-    ActiveRecord::Base.descendants.find do |model|
-      !model.abstract_class? && model.table_name == table_name
-    rescue StandardError
-      false # A descendant can raise an error for `table_name`. It is not the correct model.
+  # Whether +model+ is a concrete model that declares +table_name+.
+  #
+  # @param model [Class] a descendant of +ActiveRecord::Base+.
+  # @param table_name [String] the name of a table.
+  # @return [Boolean]
+  def self.declares_table?(model, table_name)
+    !model.abstract_class? && model.table_name == table_name
+  rescue StandardError
+    # A descendant can raise while computing its `table_name`. Then it's not
+    # the model we want.
+    false
+  end
+
+  # The model that declares +table_name+, if the application loaded that model.
+  #
+  # +column_of+ only gets a table name, and the table may be in a different
+  # database than +ActiveRecord::Base+. The model that declares it knows which
+  # pool to use.
+  #
+  # @param table_name [String] the name of a table.
+  # @return [Class, nil] the model that declares the table, or nil if no loaded
+  #   model does.
+  def self.model_of(table_name)
+    if !defined?(ActiveRecord::Base) || !ActiveRecord::Base.respond_to?(:descendants)
+      nil
+    else
+      ActiveRecord::Base.descendants.find { |model| declares_table?(model, table_name) }
     end
   end
 
-  # Schema cache queries for `pool`, as a callable object.
+  # Schema cache queries for +pool+, as a callable object.
   #
   # Different versions of activerecord keep the schema cache in different
-  # locations. `columns_hash` and `data_source_exists?` both use that cache.
-  # Thus this method holds the conditions for the version, one time.
+  # places. +columns_hash+ and +data_source_exists?+ both read it, so this
+  # method does the version check once.
   #
-  # The method returns nil if a pool has no schema cache (activerecord < 5.0).
+  # @param pool [ActiveRecord::ConnectionAdapters::ConnectionPool] the pool to
+  #   read the schema cache of.
+  # @return [Proc, nil] a callable taking a query name and a table name, or nil
+  #   if the pool has no schema cache (activerecord < 5.0).
   def self.schema_cache_query(pool)
     if pool.respond_to?(:pool_config)
       if pool.pool_config.respond_to?(:schema_reflection) # activerecord >= 7.1
@@ -90,27 +122,36 @@ module ArelExtensions
     end
   end
 
+  # The column +column_name+ of the table +table_name+.
+  #
+  # @param table_name [String] the name of a table.
+  # @param column_name [String] the name of a column of that table.
+  # @return [ActiveRecord::ConnectionAdapters::Column, nil] the column, or nil
+  #   if the database has no such column.
   def self.column_of(table_name, column_name)
     model = model_of(table_name)
     pool = (model || ActiveRecord::Base).connection_pool
     use_arel_table = !ActiveRecord::Base.connected?
 
-    return column_of_via_arel_table(table_name, column_name) if use_arel_table
-
-    query = schema_cache_query(pool)
-
-    return column_of_via_arel_table(table_name, column_name) if query.nil? # activerecord < 5.0
-
-    # A name that no model declares is not always a table. `Arel::Table.new`
-    # also makes the name of a common table expression. The database has no data
-    # for such a name, thus the reflection fails. On postgres, a failed statement
-    # also stops the transaction. Then all the statements after it fail.
-    #
-    # The schema cache keeps the list of data sources. It does not keep a failed
-    # reflection. Thus this method examines that list first.
-    return nil if model.nil? && !query.call(:data_source_exists?, table_name)
-
-    query.call(:columns_hash, table_name)[column_name]
+    if use_arel_table
+      column_of_via_arel_table(table_name, column_name)
+    else
+      query = schema_cache_query(pool)
+      if query.nil? # activerecord < 5.0
+        column_of_via_arel_table(table_name, column_name)
+      elsif model.nil? && !query.call(:data_source_exists?, table_name)
+        # If no model declares the name, it may not be a table:
+        # `Arel::Table.new` also names a common table expression. Reflecting one
+        # of those fails, and on postgres a failed statement kills the
+        # surrounding transaction.
+        #
+        # Check the data source list first. The schema cache keeps it, and never
+        # caches a failed reflection.
+        nil
+      else
+        query.call(:columns_hash, table_name)[column_name]
+      end
+    end
   rescue ActiveRecord::ConnectionNotEstablished
     column_of_via_arel_table(table_name, column_name)
   rescue ActiveRecord::StatementInvalid

--- a/lib/arel_extensions/helpers.rb
+++ b/lib/arel_extensions/helpers.rb
@@ -46,28 +46,62 @@ module ArelExtensions
     nil
   end
 
-  def self.column_of(table_name, column_name)
-    pool = ActiveRecord::Base.connection.pool
-    use_arel_table = !ActiveRecord::Base.connected? \
-      || (pool.respond_to?(:schema_cache) && pool.schema_cache.nil?)
+  # The model that declares `table_name`, if the application loaded that model.
+  #
+  # `column_of` gets only the name of a table. That table can be in a different
+  # database than the database of `ActiveRecord::Base`. If an application has
+  # more than one database, the model that declares the table knows the correct
+  # pool.
+  def self.model_of(table_name)
+    return nil unless defined?(ActiveRecord::Base) && ActiveRecord::Base.respond_to?(:descendants)
 
-    if use_arel_table
-      column_of_via_arel_table(table_name, column_name)
-    elsif pool.respond_to?(:pool_config)
-      if pool.pool_config.respond_to?(:schema_reflection) # activerecord >= 7.1
-        if ActiveRecord.version >= Gem::Version.create('7.2')
-          pool.pool_config.schema_reflection.columns_hash(pool, table_name)[column_name]
-        else
-          pool.pool_config.schema_reflection.columns_hash(ActiveRecord::Base.connection, table_name)[column_name]
-        end
-      else # activerecord < 7.1
-        pool.pool_config.schema_cache.columns_hash(table_name)[column_name]
-      end
-    elsif pool.respond_to?(:schema_cache) # activerecord < 6.1
-      pool.schema_cache.columns_hash(table_name)[column_name]
-    else # activerecord < 5.0
-      column_of_via_arel_table(table_name, column_name)
+    ActiveRecord::Base.descendants.find do |model|
+      !model.abstract_class? && model.table_name == table_name
+    rescue StandardError
+      false # A descendant can raise an error for `table_name`. It is not the correct model.
     end
+  end
+
+  # Schema cache queries for `pool`, as a callable object.
+  #
+  # Different versions of activerecord keep the schema cache in different
+  # locations. `columns_hash` and `data_source_exists?` both use that cache.
+  # Thus this method holds the conditions for the version, one time.
+  #
+  # The method returns nil if a pool has no schema cache (activerecord < 5.0).
+  def self.schema_cache_query(pool)
+    if pool.respond_to?(:pool_config)
+      if pool.pool_config.respond_to?(:schema_reflection) # activerecord >= 7.1
+        reflection = pool.pool_config.schema_reflection
+        target = ActiveRecord.version >= Gem::Version.create('7.2') ? pool : pool.connection
+        ->(query, table_name) { reflection.public_send(query, target, table_name) }
+      else # activerecord < 7.1
+        cache = pool.pool_config.schema_cache
+        ->(query, table_name) { cache.public_send(query, table_name) }
+      end
+    elsif pool.respond_to?(:schema_cache) && pool.schema_cache
+      cache = pool.schema_cache
+      ->(query, table_name) { cache.public_send(query, table_name) }
+    elsif pool.respond_to?(:connection) && pool.connection.respond_to?(:schema_cache)
+      # activerecord <= 6.0 keeps the cache on the connection, and
+      # `pool.schema_cache` is nil there.
+      cache = pool.connection.schema_cache
+      ->(query, table_name) { cache.public_send(query, table_name) }
+    end
+  end
+
+  def self.column_of(table_name, column_name)
+    model = model_of(table_name)
+    pool = (model || ActiveRecord::Base).connection_pool
+    use_arel_table = !ActiveRecord::Base.connected?
+
+    return column_of_via_arel_table(table_name, column_name) if use_arel_table
+
+    query = schema_cache_query(pool)
+
+    return column_of_via_arel_table(table_name, column_name) if query.nil? # activerecord < 5.0
+
+    query.call(:columns_hash, table_name)[column_name]
   rescue ActiveRecord::ConnectionNotEstablished
     column_of_via_arel_table(table_name, column_name)
   rescue ActiveRecord::StatementInvalid

--- a/lib/arel_extensions/helpers.rb
+++ b/lib/arel_extensions/helpers.rb
@@ -101,6 +101,15 @@ module ArelExtensions
 
     return column_of_via_arel_table(table_name, column_name) if query.nil? # activerecord < 5.0
 
+    # A name that no model declares is not always a table. `Arel::Table.new`
+    # also makes the name of a common table expression. The database has no data
+    # for such a name, thus the reflection fails. On postgres, a failed statement
+    # also stops the transaction. Then all the statements after it fail.
+    #
+    # The schema cache keeps the list of data sources. It does not keep a failed
+    # reflection. Thus this method examines that list first.
+    return nil if model.nil? && !query.call(:data_source_exists?, table_name)
+
     query.call(:columns_hash, table_name)[column_name]
   rescue ActiveRecord::ConnectionNotEstablished
     column_of_via_arel_table(table_name, column_name)

--- a/lib/arel_extensions/math.rb
+++ b/lib/arel_extensions/math.rb
@@ -38,12 +38,7 @@ module ArelExtensions
       when Arel::Nodes::Function
         Arel.grouping(Arel::Nodes::Addition.new(self, other))
       else
-        col =
-          if is_a?(Arel::Attribute) && respond_to?(:type_caster) && able_to_type_cast?
-            type_caster
-          elsif respond_to?(:relation)
-            Arel.column_of(relation.table_name, name.to_s)
-          end
+        col = ArelExtensions.type_source_of(self)
         if col
           arg = col.type
           if arg == :integer || !arg
@@ -83,23 +78,13 @@ module ArelExtensions
       when Arel::Nodes::Function
         Arel.grouping(Arel::Nodes::Subtraction.new(self, Arel.quoted(other)))
       else
-        col =
-          if is_a?(Arel::Attribute) && respond_to?(:type_caster) && able_to_type_cast?
-            type_caster
-          elsif respond_to?(:relation)
-            Arel.column_of(relation.table_name, name.to_s)
-          end
+        col = ArelExtensions.type_source_of(self)
         if col
           arg = col.type
           if %i[date datetime].include?(arg)
             case other
             when Arel::Attributes::Attribute
-              col2 =
-                if other.is_a?(Arel::Attribute) && other.respond_to?(:type_caster) && other.able_to_type_cast?
-                  other.type_caster
-                elsif other.respond_to?(:relation)
-                  Arel.column_of(other.relation.table_name, other.name.to_s)
-                end
+              col2 = ArelExtensions.type_source_of(other)
               if col2
                 arg2 = col2.type
                 if %i[date datetime].include?(arg2)

--- a/lib/arel_extensions/nodes/case.rb
+++ b/lib/arel_extensions/nodes/case.rb
@@ -61,7 +61,7 @@ module ArelExtensions
           when Date, DateTime, Time
             :datetime
           when Arel::Attributes::Attribute
-            Arel.column_of(obj.relation.table_name, obj.name.to_s)&.type || :string
+            ArelExtensions.type_of(obj) || :string
           else
             :string
           end

--- a/lib/arel_extensions/nodes/function.rb
+++ b/lib/arel_extensions/nodes/function.rb
@@ -55,7 +55,7 @@ module ArelExtensions
       def type_of_attribute(att)
         case att
         when Arel::Attributes::Attribute
-          Arel.column_of(att.relation.table_name, att.name.to_s)&.type || att
+          ArelExtensions.type_of(att) || att
         when ArelExtensions::Nodes::Function
           att.return_type
           #        else

--- a/test/with_ar/all_agnostic_test.rb
+++ b/test/with_ar/all_agnostic_test.rb
@@ -143,6 +143,39 @@ module ArelExtensions
         assert_equal 'updated_at', Arel.column_of('user_tests', 'updated_at').name, 'An existing column name should be returned'
       end
 
+      # True if `blk` asked the database for a type, false if it used a type caster.
+      def asked_the_database(&blk)
+        original = ArelExtensions.method(:column_of)
+        asked = false
+        ArelExtensions.define_singleton_method(:column_of) { |*args|
+          asked = true
+          original.call(*args)
+        }
+        blk.call
+        asked
+      ensure
+        ArelExtensions.define_singleton_method(:column_of, original)
+      end
+
+      def test_type_of_attribute_asks_the_model_first
+        # `User.arel_table` made `@score`, thus `@score` has a type caster. The
+        # type caster knows the type. A query to the database is not necessary.
+        # If the model connects to a different database, the query also fails.
+        node = nil
+        asked = asked_the_database { node = @score.coalesce(0) }
+
+        assert_equal :decimal, node.return_type, 'The type of a model-backed attribute should be resolved'
+        refute asked, 'The method must not ask the database for a type that the model has'
+      end
+
+      def test_type_of_attribute_falls_back_to_the_database
+        node = nil
+        asked = asked_the_database { node = Arel::Table.new(:user_tests)[:score].coalesce(0) }
+
+        assert_equal :decimal, node.return_type, 'An attribute with no model must still get its type'
+        assert asked, 'Only the database can give the type'
+      end
+
       # Math Functions
       def test_classical_arel
         assert_in_epsilon 42.16, t(@laure, @score + 22), 0.01

--- a/test/with_ar/all_agnostic_test.rb
+++ b/test/with_ar/all_agnostic_test.rb
@@ -143,6 +143,26 @@ module ArelExtensions
         assert_equal 'updated_at', Arel.column_of('user_tests', 'updated_at').name, 'An existing column name should be returned'
       end
 
+      # The SQL statements that `blk` sends to the database.
+      def statements(&blk)
+        sent = []
+        subscriber = ActiveSupport::Notifications.subscribe('sql.active_record') { |*, payload| sent << payload[:sql] }
+        blk.call
+        sent
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber)
+      end
+
+      def test_column_of_does_not_reflect_a_name_the_database_does_not_have
+        # `Arel::Table.new` also makes the name of a common table expression.
+        # The database has no data for such a name. The cache does not keep a
+        # failed reflection, thus the reflection occurred at each call. The
+        # cache keeps the list of data sources.
+        Arel.column_of('chupa', 'maflavla') # ask once, so the data source list is loaded
+
+        assert_empty(statements { 3.times { Arel.column_of('chupa', 'maflavla') } })
+      end
+
       # True if `blk` asked the database for a type, false if it used a type caster.
       def asked_the_database(&blk)
         original = ArelExtensions.method(:column_of)

--- a/test/with_ar/multi_database_agnostic_test.rb
+++ b/test/with_ar/multi_database_agnostic_test.rb
@@ -1,0 +1,111 @@
+require 'arelx_test_helper'
+
+module ArelExtensions
+  module WithAr
+    # `column_of` gets only the name of a table. Thus it must find the database
+    # that owns that table. These tests make a second database. That database
+    # has a table that the primary database does not have. Only the model that
+    # declares the table connects to the second database.
+    class MultiDatabaseTest < Minitest::Test
+      SQLITE = (RUBY_PLATFORM == 'java' ? :'jdbc-sqlite' : :sqlite).freeze
+
+      class SecondaryBase < ActiveRecord::Base
+        self.abstract_class = true
+      end
+
+      class Amount < SecondaryBase
+        self.table_name = 'amount_tests'
+      end
+
+      class Member < ActiveRecord::Base
+        self.table_name = 'member_tests'
+      end
+
+      def connect_db
+        ActiveRecord::Base.configurations = ConfigLoader.load('test/database.yml')
+        if ENV['DB'] == 'oracle' && ((defined?(RUBY_ENGINE) && RUBY_ENGINE == 'rbx') || (RUBY_PLATFORM == 'java')) # not supported
+          skip "Platform not supported (DB: #{ENV['DB']}, RUBY_ENGINE: #{RUBY_ENGINE}, RUBY_PLATFORM: #{RUBY_PLATFORM})"
+        end
+        @env_db = ENV['DB']
+        ActiveRecord::Base.establish_connection(@env_db.try(:to_sym) || SQLITE)
+        @cnx = ActiveRecord::Base.connection
+        Arel::Table.engine = ActiveRecord::Base
+        # An in-memory sqlite database is always a different database than
+        # the primary database.
+        SecondaryBase.establish_connection(SQLITE)
+        @secondary_cnx = SecondaryBase.connection
+      end
+
+      def setup_db
+        @cnx.drop_table(:member_tests) rescue nil
+        @cnx.create_table :member_tests do |t|
+          t.column :name, :string
+          t.column :score, :decimal, precision: 20, scale: 10
+        end
+        # No model declares this table. Only the primary database has data for it.
+        @cnx.drop_table(:orphan_tests) rescue nil
+        @cnx.create_table :orphan_tests do |t|
+          t.column :quantity, :integer
+        end
+        @secondary_cnx.drop_table(:amount_tests) rescue nil
+        @secondary_cnx.create_table :amount_tests do |t|
+          t.column :debit, :decimal, precision: 20, scale: 10
+        end
+      end
+
+      def setup
+        connect_db
+        setup_db
+      end
+
+      def teardown
+        @cnx.drop_table(:member_tests) rescue nil
+        @cnx.drop_table(:orphan_tests) rescue nil
+        SecondaryBase.remove_connection
+      end
+
+      # The SQL statements that `blk` sends to the primary database.
+      def primary_statements(&blk)
+        statements = []
+        subscriber =
+          ActiveSupport::Notifications.subscribe('sql.active_record') do |*, payload|
+            statements << payload[:sql] if payload[:connection]&.pool == ActiveRecord::Base.connection_pool
+          end
+        blk.call
+        statements
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber)
+      end
+
+      def test_column_of_secondary_database
+        assert_equal :decimal, Arel.column_of('amount_tests', 'debit')&.type, 'A column of a table in a different database must be resolved'
+        assert_nil Arel.column_of('amount_tests', 'maflavla'), 'Existent table but non-existent column should return nil'
+      end
+
+      def test_column_of_primary_database
+        assert_equal :string, Arel.column_of('member_tests', 'name')&.type, 'A column of a table that a model declares must still be resolved'
+        assert_equal :integer, Arel.column_of('orphan_tests', 'quantity')&.type, 'A column of a table that no model declares must still be resolved'
+        assert_nil Arel.column_of('chupa', 'maflavla'), 'Non-existent table and column should return nil'
+      end
+
+      def test_column_of_does_not_touch_the_primary_database_for_a_secondary_table
+        skip 'sql.active_record does not carry the connection before rails 6' if ACTIVE_RECORD_VERSION < V6
+
+        # The primary database has no `amount_tests` table. Thus a reflection
+        # on the primary database fails. On postgres, the failed statement also
+        # stops the transaction. Then all the statements after it fail.
+        assert_empty(primary_statements { Arel.column_of('amount_tests', 'debit') })
+      end
+
+      def test_operators_dispatch_on_the_type_of_a_secondary_database_column
+        # If the type is not available, arel_extensions uses the string type.
+        # Then it makes `+` into a concatenation. A function asks for the type.
+        # An attribute has its own type caster.
+        primary = (Member.arel_table[:score].coalesce(0) + Member.arel_table[:score].coalesce(0)).to_sql
+        secondary = (Amount.arel_table[:debit].coalesce(0) + Amount.arel_table[:debit].coalesce(0)).to_sql
+
+        assert_equal primary, secondary.gsub('amount_tests', 'member_tests').gsub('debit', 'score')
+      end
+    end
+  end
+end

--- a/test/with_ar/multi_database_agnostic_test.rb
+++ b/test/with_ar/multi_database_agnostic_test.rb
@@ -2,10 +2,10 @@ require 'arelx_test_helper'
 
 module ArelExtensions
   module WithAr
-    # `column_of` gets only the name of a table. Thus it must find the database
-    # that owns that table. These tests make a second database. That database
-    # has a table that the primary database does not have. Only the model that
-    # declares the table connects to the second database.
+    # `column_of` only gets a table name, so it has to find the database that
+    # owns the table. These tests set up a second database with a table the
+    # primary one does not have. Only the model that declares that table can
+    # reach it.
     class MultiDatabaseTest < Minitest::Test
       SQLITE = (RUBY_PLATFORM == 'java' ? :'jdbc-sqlite' : :sqlite).freeze
 
@@ -30,8 +30,6 @@ module ArelExtensions
         ActiveRecord::Base.establish_connection(@env_db.try(:to_sym) || SQLITE)
         @cnx = ActiveRecord::Base.connection
         Arel::Table.engine = ActiveRecord::Base
-        # An in-memory sqlite database is always a different database than
-        # the primary database.
         SecondaryBase.establish_connection(SQLITE)
         @secondary_cnx = SecondaryBase.connection
       end
@@ -64,17 +62,53 @@ module ArelExtensions
         SecondaryBase.remove_connection
       end
 
-      # The SQL statements that `blk` sends to the primary database.
+      # The statements that `blk` sends to the primary database.
+      #
+      # This only watches. If `blk` raises, the exception propagates and we lose
+      # the collected statements.
       def primary_statements(&blk)
         statements = []
+        primary_pool = ActiveRecord::Base.connection_pool
         subscriber =
           ActiveSupport::Notifications.subscribe('sql.active_record') do |*, payload|
-            statements << payload[:sql] if payload[:connection]&.pool == ActiveRecord::Base.connection_pool
+            cnx = payload[:connection]
+            statements << payload[:sql] if cnx.respond_to?(:pool) && cnx.pool == primary_pool
           end
         blk.call
         statements
       ensure
         ActiveSupport::Notifications.unsubscribe(subscriber)
+      end
+
+      # Every test here assumes two separate databases, each with a table the
+      # other does not have.
+      def test_the_two_databases_are_distinct
+        refute_same ActiveRecord::Base.connection_pool, SecondaryBase.connection_pool, 'The secondary model must not share the pool of the primary'
+
+        assert @cnx.data_source_exists?('member_tests'), 'The primary database must have its own table'
+        refute @cnx.data_source_exists?('amount_tests'), 'The primary database must not have the table of the secondary database'
+
+        assert @secondary_cnx.data_source_exists?('amount_tests'), 'The secondary database must have its own table'
+        refute @secondary_cnx.data_source_exists?('member_tests'), 'The secondary database must not have the table of the primary database'
+      end
+
+      # Guards the two tests below that assert on an empty result. An empty
+      # result has to mean nothing ran. It must not mean the subscriber never
+      # sees anything.
+      def test_primary_statements_observes_the_primary_database
+        skip 'sql.active_record does not carry the connection before rails 6' if ACTIVE_RECORD_VERSION < V6
+
+        observed = primary_statements { @cnx.select_all(Member.arel_table.project(Arel.star).to_sql) }
+        assert(observed.any? { |sql| sql.include?('member_tests') }, "A statement of the primary database must be observed, got #{observed.inspect}")
+
+        observed = primary_statements { @secondary_cnx.select_all(Amount.arel_table.project(Arel.star).to_sql) }
+        assert_empty observed, 'A statement of the secondary database must not be observed'
+      end
+
+      def test_primary_statements_does_not_swallow_the_exception_of_its_block
+        boom = Class.new(StandardError)
+
+        assert_raises(boom) { primary_statements { raise(boom) } }
       end
 
       def test_column_of_secondary_database
@@ -91,20 +125,45 @@ module ArelExtensions
       def test_column_of_does_not_touch_the_primary_database_for_a_secondary_table
         skip 'sql.active_record does not carry the connection before rails 6' if ACTIVE_RECORD_VERSION < V6
 
-        # The primary database has no `amount_tests` table. Thus a reflection
-        # on the primary database fails. On postgres, the failed statement also
-        # stops the transaction. Then all the statements after it fail.
-        assert_empty(primary_statements { Arel.column_of('amount_tests', 'debit') })
+        # The primary database has no `amount_tests` table, so reflecting it
+        # there fails. On postgres that also kills the surrounding transaction.
+        assert_empty(primary_statements { Arel.column_of('amount_tests', 'debit') }, 'Reflecting a secondary-database table must not query the primary')
       end
 
-      def test_operators_dispatch_on_the_type_of_a_secondary_database_column
-        # If the type is not available, arel_extensions uses the string type.
-        # Then it makes `+` into a concatenation. A function asks for the type.
-        # An attribute has its own type caster.
-        primary = (Member.arel_table[:score].coalesce(0) + Member.arel_table[:score].coalesce(0)).to_sql
-        secondary = (Amount.arel_table[:debit].coalesce(0) + Amount.arel_table[:debit].coalesce(0)).to_sql
+      def test_model_of_finds_the_model_that_declares_a_table
+        assert_equal Amount, ArelExtensions.model_of('amount_tests'), 'The model declaring the secondary table'
+        assert_equal Member, ArelExtensions.model_of('member_tests'), 'The model declaring the primary table'
+        assert_nil ArelExtensions.model_of('orphan_tests'), 'A table that no model declares has no model'
+      end
 
-        assert_equal primary, secondary.gsub('amount_tests', 'member_tests').gsub('debit', 'score')
+      # `+` on a decimal is an addition, and on a string a concatenation. It
+      # dispatches on the `return_type` of the function, which comes from the
+      # attribute. So the column type has to travel from the model to the SQL.
+      # Each assertion checks one step.
+      def test_operators_dispatch_on_the_type_of_a_secondary_database_column
+        attribute = Amount.arel_table[:debit]
+
+        assert_equal :decimal, ArelExtensions.type_of(attribute), 'The type must come from the model that declares the table'
+        assert_equal :decimal, attribute.coalesce(0).return_type, 'The function must take the type of its attribute'
+
+        # `+` renders differently per adapter, so compare against the same
+        # expression on a decimal column of the primary database.
+        primary = (Member.arel_table[:score].coalesce(0) + Member.arel_table[:score].coalesce(0)).to_sql
+        secondary = (attribute.coalesce(0) + attribute.coalesce(0)).to_sql
+
+        assert_equal primary, secondary.gsub('amount_tests', 'member_tests').gsub('debit', 'score'), 'A secondary decimal column must render like a primary one'
+      end
+
+      # The opposite case, which is what `master` did with a secondary-database
+      # column. No type means `+` concatenates. A bare `Arel::Table` has no type
+      # caster, and no model declares this name, so nothing supplies a type.
+      def test_an_attribute_with_no_type_concatenates
+        attribute = Arel::Table.new('chupa')[:maflavla]
+
+        assert_nil ArelExtensions.type_of(attribute), 'An attribute of an unknown table has no type'
+
+        expected = attribute.coalesce('').concat(attribute.coalesce('')).to_sql
+        assert_equal expected, (attribute.coalesce('') + attribute.coalesce('')).to_sql, 'With no type, `+` must be a concatenation'
       end
     end
   end


### PR DESCRIPTION
## Problem

`ArelExtensions.column_of` gets the name of a table, nothing more. It resolves the pool as `ActiveRecord::Base.connection.pool`, whatever table it was asked about. If an application has more than one database, a table declared by a model that connects elsewhere is reflected on the primary connection, where that table does not exist.

```ruby
ActiveRecord::Base.transaction do
  Amount.arel_table[:debit].coalesce(0)  # amount_tests is in a secondary database
  User.count                             # => PG::InFailedSqlTransaction
end
```

`StatementInvalid` is rescued to nil, so nothing surfaces. Three costs: a failed statement on every call, since a failed reflection is never cached; the type that the lookup exists to find, so `coalesce(a, 0) + coalesce(b, 0)` renders as `||`; and on postgres the surrounding transaction.

## Changes

**1. Take an attribute's type from its model.** `Function#type_of_attribute` and `Case` ask `column_of`, but an attribute from a model's `arel_table` carries a type caster that knows the answer. `math.rb:42` already prefers it. This costs no query at all.

**2. Reflect on the database that owns the table.** For anything with no type caster — an attribute off a bare `Arel::Table`, the sqlite and oracle visitors' `get_time_converted` — `column_of` now resolves the pool from the model that declares the table, and falls back to `ActiveRecord::Base`. The version branching moves into `schema_cache_query`, unchanged.

**3. Do not reflect a name the database does not have.** `Arel::Table.new` also names a common table expression. The list of data sources is cached, unlike a failed reflection.

## Tests

Each commit has a test that fails without it. `test/with_ar/multi_database_agnostic_test.rb` is new: it holds a second, in-memory sqlite database, reachable only through the model that declares its table, so it runs whatever the primary adapter is.

Postgres primary, sqlite secondary, one transaction:

| | `master` | this branch |
|---|---|---|
| `column_of('amount_tests', 'debit').type` | `nil` | `:decimal` |
| `User.count`, same transaction | `PG::InFailedSqlTransaction` | `0` |

Repeated lookups of a name the database does not have:

| | `master` | this branch |
|---|---|---|
| first call | 1 statement, fails | 2 statements, loads the data source list |
| every call after | 1 statement, fails | 0 |

Run locally: `test:to_sql`, and the sqlite suite on activerecord 6.1, 7.1, 7.2 and 8.1 (78 runs, 317 assertions, 0 failures). Postgres on 8.1 passes too, apart from one pre-existing `lc_time: "en_US.utf8"` error that fails the same way on `master` on my machine. mysql, mssql and oracle are left to CI.

Behaviour was diffed against `master` on activerecord 6.1, 7.0, 7.1, 7.2 and 8.1 across nine call shapes. Only the secondary-database cases differ.
