### PR TITLE
MS SQL: FIx crash on calls to limit/offset over a union

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,9 @@
 - MS SQL: `SELECT` over a derived table (e.g. a `UNION` alias) with a `limit`/`offset`
   no longer crashes while generating the SQL. Such a query still needs an explicit
   `order`, since SQL Server requires `ORDER BY` with `OFFSET`/`FETCH`.
+- MS SQL: support for `regexp_replace` is added, but note that this requires an
+  extension or a paid subscription so don't expect it to work out-of-the-box for
+  freely distributed versions of the MS SQL Server.
 
 ## Release v2.5.0/v1.7.0 (02-09-2026)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,9 @@
   for that name. `Arel::Table.new` also makes the name of a common table expression. A
   reflection on such a name can only fail. The schema cache keeps the list of data sources,
   thus `column_of` examines that list first.
+- MS SQL: `SELECT` over a derived table (e.g. a `UNION` alias) with a `limit`/`offset`
+  no longer crashes while generating the SQL. Such a query still needs an explicit
+  `order`, since SQL Server requires `ORDER BY` with `OFFSET`/`FETCH`.
 
 ## Release v2.5.0/v1.7.0 (02-09-2026)
 

--- a/lib/arel_extensions/visitors.rb
+++ b/lib/arel_extensions/visitors.rb
@@ -98,5 +98,31 @@ if defined?(Arel::Visitors::SQLServer)
       end
       old_visit_Arel_Nodes_SelectStatement(o, collector)
     end
+
+    # When a query has a limit/offset but no order, the SQL Server adapter tries
+    # to add a deterministic ORDER BY on the primary key of the queried table
+    # (make_Fetch_Possible_And_Deterministic -> table_From_Statement, upstream).
+    #
+    # When the query reads FROM a derived table (e.g. a UNION or a sub-select
+    # alias, as produced by our union helpers) there is no physical table to look
+    # up: upstream's table_From_Statement returns an Arel node that has no #name
+    # and primary_Key_From_Table crashes while generating the SQL.
+    #
+    # Resolve the real Arel::Table when the alias just wraps one; otherwise return
+    # nil so the adapter simply skips the primary-key ordering. A limit/offset
+    # over a derived table then still needs an explicit .order(...) to run, since
+    # SQL Server requires ORDER BY with OFFSET/FETCH.
+    alias old_arelx_table_From_Statement table_From_Statement rescue nil
+    def table_From_Statement(o)
+      core = o.cores.first
+      from = core && (core.from || (core.source.is_a?(Arel::Nodes::JoinSource) ? core.source.left : nil))
+
+      if from.is_a?(Arel::Nodes::TableAlias) || from.is_a?(Arel::Nodes::As)
+        rel = from.respond_to?(:relation) ? from.relation : from.left
+        rel.is_a?(Arel::Table) ? rel : nil
+      else
+        old_arelx_table_From_Statement(o)
+      end
+    end
   end
 end

--- a/lib/arel_extensions/visitors/mssql.rb
+++ b/lib/arel_extensions/visitors/mssql.rb
@@ -304,6 +304,17 @@ module ArelExtensions
         end
       end
 
+      def visit_ArelExtensions_Nodes_RegexpReplace o, collector # rubocop:disable Naming/MethodName
+          collector << "dbo.REGEXP_REPLACE("
+          visit o.left, collector
+          collector << LOADED_VISITOR::COMMA
+          visit Arel::Nodes.build_quoted(o.pattern&.source), collector
+          collector << LOADED_VISITOR::COMMA
+          visit o.substitute, collector
+          collector << ")"
+          collector
+      end
+
       def visit_ArelExtensions_Nodes_Round(o, collector)
         collector << 'ROUND('
         o.expressions.each_with_index { |arg, i|

--- a/test/with_ar/all_agnostic_test.rb
+++ b/test/with_ar/all_agnostic_test.rb
@@ -1084,6 +1084,19 @@ module ArelExtensions
         assert (@ut.project(@age) + @ut.project(@age)).as('toto').table_name # as on union should answer to table_name (TableAlias)
       end
 
+      def test_union_with_limit
+        # Regression on SQL Server: SELECTing from a derived table (a UNION alias)
+        # with a limit/offset used to crash while the adapter tried to add a
+        # deterministic ORDER BY from the (non existent) derived table's primary key.
+        #
+        # SQL Server still requires an explicit ORDER BY to use OFFSET/FETCH, so
+        # the query carries its own order.
+        u = @ut.project(@age).where(@age.gt(22)) + @ut.project(@age).where(@age.lt(0))
+        rel = User.select('*').from(u.as('my_union')).order(Arel.sql('age'))
+        assert_equal 2, rel.limit(2).length
+        assert_equal 2, rel.offset(1).limit(2).length
+      end
+
       # Case clause
       def test_case
         assert_equal 4, User.find_by_sql(@ut.project(@score.when(20.16).then(1).else(0).as('score_bin')).to_sql).sum(&:score_bin)


### PR DESCRIPTION
And also add `regexp_replace` support (which is a paid option)